### PR TITLE
Update post.php

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -83,6 +83,21 @@ class WordPress_GitHub_Sync_Post {
   }
 
   /**
+  * Returns the post_content
+  *
+  * Markdownify's the content if applicable
+  */
+  function content() {
+    $content = $this->post->post_content;
+  
+    if ( function_exists( 'wpmarkdown_html_to_markdown' ) ) {
+      $content = wpmarkdown_html_to_markdown( $content );
+    }
+  
+    return apply_filters( 'wpghs_content', $content );
+  }
+
+  /**
    * Calculates the proper GitHub path for a given post
    *
    * Returns (string) the path relative to repo root
@@ -181,7 +196,7 @@ class WordPress_GitHub_Sync_Post {
         ),
       "body"    => json_encode( array(
           "message" => "Syncing " . $this->github_path() . " from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ")",
-          "content" => base64_encode($this->front_matter() . trim(html_entity_decode($this->post->post_content))),
+          "content" => base64_encode( $this->front_matter() . trim( $this->content() ) ),
           "author"  => $this->last_modified_author(),
           "sha"     => $this->sha()
         ) )
@@ -219,9 +234,13 @@ class WordPress_GitHub_Sync_Post {
       $meta = array();
     }
 
+    if ( function_exists( 'wpmarkdown_markdown_to_html' ) ) {
+      $body = wpmarkdown_markdown_to_html( $body );
+    }
+
     wp_update_post( array_merge( $meta, array(
         "ID"           => $this->id,
-        "post_content" => trim(html_entity_decode($body))
+        "post_content" => trim( $body )
       ))
     );
   }


### PR DESCRIPTION
Things changed:

* exports and imports now from `.md` instead of `.html` (works well with GitHub, even the YAML header)
* updated the YAML header to include the post date, and changed path uri to actual article uri
* GitHub commit notes are slightly more verbose to include site url (useful with WPMU setups)