### PR TITLE
Improve error messages & export reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+    - 5.6
+
+env:
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=1
+    - WP_VERSION=3.8 WP_MULTISITE=0
+    - WP_VERSION=3.8 WP_MULTISITE=1
+
+before_script:
+    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    - composer install
+
+script: phpunit

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=/tmp/wordpress/
+
+set -ex
+
+install_wp() {
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then 
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite
+	mkdir -p $WP_TESTS_DIR
+	cd $WP_TESTS_DIR
+	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+
+	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
+	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
+	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
+	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
+	sed $ioption "s|localhost|${DB_HOST}|" wp-tests-config.php
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -80,6 +80,20 @@ class WordPress_GitHub_Sync_Admin {
       delete_option( '_wpghs_export_started' );
     }
 
+    if ( $message = get_option( '_wpghs_export_error'  ) ) { ?>
+      <div class="error">
+        <p><?php _e( 'Export to GitHub failed with error:', WordPress_GitHub_Sync::$text_domain ); ?> <?php echo esc_html( $message ) ;?></p>
+      </div><?php
+      delete_option( '_wpghs_export_error' );
+    }
+
+    if ( 'yes' === get_option( '_wpghs_export_complete'  ) ) { ?>
+      <div class="updated">
+        <p><?php _e( 'Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain ); ?></p>
+      </div><?php
+      delete_option( '_wpghs_export_complete' );
+    }
+
   }
 
   /**

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -67,9 +67,20 @@ class WordPress_GitHub_Sync_Admin {
   }
 
   /**
-   * Empty section callback
+   * Displays settings messages from background processes
    */
-  function section_callback() { }
+  function section_callback() {
+    if ( get_current_screen()->id != "settings_page_" . WordPress_GitHub_Sync::$text_domain)
+      return;
+
+    if ('yes' === get_option( '_wpghs_export_started' )) { ?>
+      <div class="updated">
+        <p><?php _e( 'Export to GitHub started.', WordPress_GitHub_Sync::$text_domain ); ?></p>
+      </div><?php
+      delete_option( '_wpghs_export_started' );
+    }
+
+  }
 
   /**
    * Add options menu to admin navbar

--- a/lib/post.php
+++ b/lib/post.php
@@ -189,19 +189,22 @@ class WordPress_GitHub_Sync_Post {
     $response = wp_remote_request( $this->api_endpoint(), $args );
     $body = wp_remote_retrieve_body($response);
     $data = json_decode($body);
+
     if ($data && isset($data->content) && !isset($data->errors)) {
       $sha = $data->content->sha;
       add_post_meta( $this->id, '_sha', $sha, true ) || update_post_meta( $this->id, '_sha', $sha );
     } else {
       // save a message and quit
       if ( isset($data->message) ) {
-        update_option( '_wpghs_export_error', $data->message );
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
       } elseif( empty($data) ) {
-        update_option( '_wpghs_export_error', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
       }
 
-      die();
+      return $error;
     }
+
+    return true;
   }
 
   /**

--- a/lib/post.php
+++ b/lib/post.php
@@ -292,6 +292,6 @@ class WordPress_GitHub_Sync_Post {
    * Returns String the YAML frontmatter, ready to be written to the file
    */
   function front_matter() {
-    return "---\n" . spyc_dump( $this->meta(), false, 0 ) . "---\n";
+    return Spyc::YAMLDump($this->meta(), false, false, true) . "---\n";
   }
 }

--- a/lib/post.php
+++ b/lib/post.php
@@ -193,7 +193,14 @@ class WordPress_GitHub_Sync_Post {
       $sha = $data->content->sha;
       add_post_meta( $this->id, '_sha', $sha, true ) || update_post_meta( $this->id, '_sha', $sha );
     } else {
-      wp_die( __("WordPress <--> GitHub sync error: ", WordPress_GitHub_Sync::$text_domain) . $data->message );
+      // save a message and quit
+      if ( isset($data->message) ) {
+        update_option( '_wpghs_export_error', $data->message );
+      } elseif( empty($data) ) {
+        update_option( '_wpghs_export_error', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      die();
     }
   }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+$_tests_dir = getenv('WP_TESTS_DIR');
+if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __FILE__ ) . '/../wordpress-github-sync.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+

--- a/tests/test-post.php
+++ b/tests/test-post.php
@@ -1,0 +1,19 @@
+<?php
+
+class WordPress_GitHub_Sync_Post_Test extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+		$this->id = $this->factory->post->create();
+	}
+
+	function test_should_get_id_by_path() {
+		$path = 'thepath';
+		update_post_meta( $this->id, '_wpghs_github_path', $path );
+
+		$post = new WordPress_GitHub_Sync_Post( $path );
+
+		$this->assertEquals( $this->id, $post->id );
+	}
+}
+

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -96,7 +96,7 @@ class WordPress_GitHub_Sync {
      */
     function save_post_callback($post_id) {
 
-      if ( wp_is_post_revision( $post_id ) )
+      if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) )
         return;
 
       $post = get_post($post_id);

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -204,11 +204,8 @@ class WordPress_GitHub_Sync {
       $posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ('post', 'page' )" );
 
       wp_schedule_single_event(time(), 'wpghs_export', array($posts));
-      spawn_cron(); ?>
-      <div class="updated">
-          <p><?php _e( 'Export to GitHub started.', WordPress_GitHub_Sync::$text_domain ); ?></p>
-      </div>
-      <?php
+      spawn_cron();
+      update_option( '_wpghs_export_started', 'yes' );
     }
 
     /**

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -99,6 +99,9 @@ class WordPress_GitHub_Sync {
       if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) )
         return;
 
+      if ( ! $this->oauth_token() || ! $this->repository() )
+        return
+
       $post = get_post($post_id);
 
       // Right now CPTs are not supported
@@ -120,6 +123,9 @@ class WordPress_GitHub_Sync {
      * $post_id - (int) the post to delete
      */
     function delete_post_callback( $post_id ) {
+
+      if ( ! $this->oauth_token() || ! $this->repository() )
+        return
 
       $post = get_post($post_id);
 

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -229,6 +229,8 @@ class WordPress_GitHub_Sync {
       if (!empty($posts)) {
         $nonce = wp_hash( time() );
         update_option( '_wpghs_export_nonce', $nonce );
+
+        // Request page that will continue export
         wp_remote_post( add_query_arg( 'github', 'sync', site_url( 'index.php' ) ), array(
           'body' => array(
             'posts' => $posts,
@@ -236,6 +238,8 @@ class WordPress_GitHub_Sync {
           ),
           'blocking' => false,
         ) );
+      } else {
+        update_option( '_wpghs_export_complete', 'yes' );
       }
 
       die();


### PR DESCRIPTION
Edit: Overall, this PR is intended to help clean up and improve the export process. I'm trying to make the initial export as smooth and easy to understand as possible.

Because of the hook we're firing off the error message on, we can't output to the page yet, so I refactored it to save to an option and use that to trigger the message display. I also realized this gives us a method to retrieve and display error messages, and since the new export method runs in the background and `wp_die` won't ever display anything, I refactored the exporting process to display an error (or a completion message!) properly.