### PR TITLE
Switch to using git data api

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Install the plugin and activate it via WordPress's plugin settings page.
 ### Configuring the plugin
 
 1. [Create a personal oauth token](https://github.com/settings/tokens/new) with the `public_repo` scope. If you'd prefer not to use your account, you can create another GitHub account for this. 
-2. Configure your GitHub host, repository, secret (defined in the next step),  and OAuth Token on the WordPress <--> GitHub sync settings page within WordPress's administrative interface
+2. Configure your GitHub host, repository, secret (defined in the next step),  and OAuth Token on the WordPress <--> GitHub sync settings page within WordPress's administrative interface. Make sure the repository has an initial commit or the export will fail.
 3. Create a WebHook within your repository with the provided callback URL and callback secret, using `application/json` as the content type. To set up a webhook on GitHub, head over to the **Settings** page of your repository, and click on **Webhooks & services**. After that, click on **Add webhook**.
+4. Click `Export to GitHub` or if you use WP-CLI, run `wp wpghs export all #` from the command line, where # = the user ID you'd like to commit as.
 
 ### Markdown Support
 

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,9 @@
 	"require": {
 		"php": ">=5.3.1",
 		"mustangostang/spyc": "0.5.1"
+	},
+	"require-dev": {
+		"jdgrimes/wp-http-testcase": "1.2.1",
+		"mockery/mockery": "0.9.3"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "24d9a5278c0cff9646b6bf24196531ac",
+    "hash": "436923820cf0f3952123ed3d617ed4c1",
     "packages": [
         {
             "name": "mustangostang/spyc",
@@ -54,7 +54,108 @@
             "time": "2013-02-21 10:52:01"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "jdgrimes/wp-http-testcase",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JDGrimes/wp-http-testcase.git",
+                "reference": "ad74a49c4919ec2280d7eb8687e142ec8499ad97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JDGrimes/wp-http-testcase/zipball/ad74a49c4919ec2280d7eb8687e142ec8499ad97",
+                "reference": "ad74a49c4919ec2280d7eb8687e142ec8499ad97",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "J.D. Grimes",
+                    "email": "jdg@codesymphony.co",
+                    "homepage": "http://codesymphony.co",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHPUnit testcase for WordPress code involving HTTP requests",
+            "homepage": "https://github.com/JDGrimes/wp-http-testcase",
+            "time": "2015-02-07 20:44:38"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "0.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "~0.7@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succint API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2014-12-22 10:06:19"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -4,124 +4,130 @@
  */
 class WordPress_GitHub_Sync_Admin {
 
-  /**
-   * Hook into GitHub API
-   */
-  function __construct() {
-    add_action( 'admin_menu', array( &$this, 'add_admin_menu' ) );
-    add_action( 'admin_init', array( &$this, 'register_settings' ) );
-    add_action( 'current_screen', array( &$this, 'callback' ) );
-  }
+	/**
+	 * Hook into GitHub API
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( &$this, 'add_admin_menu' ) );
+		add_action( 'admin_init', array( &$this, 'register_settings' ) );
+		add_action( 'current_screen', array( &$this, 'callback' ) );
+	}
 
-  /**
-   * Callback to render the settings page view
-   */
-  function settings_page() {
-    include dirname(dirname( __FILE__ )) . '/views/options.php';
-  }
+	/**
+	 * Callback to render the settings page view
+	 */
+	public function settings_page() {
+		include dirname( dirname( __FILE__ ) ) . '/views/options.php';
+	}
 
-  /**
-   * Callback to register the plugin's options
-   */
-  function register_settings() {
-    add_settings_section( "general", "General Settings", array(&$this, "section_callback"), WordPress_GitHub_Sync::$text_domain );
+	/**
+	 * Callback to register the plugin's options
+	 */
+	public function register_settings() {
+		add_settings_section( 'general', 'General Settings', array( &$this, 'section_callback' ), WordPress_GitHub_Sync::$text_domain );
 
-    register_setting( WordPress_GitHub_Sync::$text_domain, "wpghs_host" );
-    add_settings_field( "wpghs_host", __("GitHub hostname", WordPress_GitHub_Sync::$text_domain), array(&$this, "field_callback"), WordPress_GitHub_Sync::$text_domain, "general", array(
-        "default"   => "https://api.github.com",
-        "name"      => "wpghs_host",
-        "help_text" => __("The GitHub host to use. Can be changed to support a GitHub Enterprise installation.", WordPress_GitHub_Sync::$text_domain)
-      )
-    );
+		register_setting( WordPress_GitHub_Sync::$text_domain, 'wpghs_host' );
+		add_settings_field( 'wpghs_host', __( 'GitHub hostname', WordPress_GitHub_Sync::$text_domain ), array( &$this, 'field_callback' ), WordPress_GitHub_Sync::$text_domain, 'general', array(
+				'default'   => 'https://api.github.com',
+				'name'      => 'wpghs_host',
+				'help_text' => __( 'The GitHub host to use. Can be changed to support a GitHub Enterprise installation.', WordPress_GitHub_Sync::$text_domain )
+			)
+		);
 
-    register_setting( WordPress_GitHub_Sync::$text_domain, "wpghs_repository" );
-    add_settings_field( "wpghs_repository", __("Repository",WordPress_GitHub_Sync::$text_domain), array(&$this, "field_callback"), WordPress_GitHub_Sync::$text_domain, "general", array(
-        "default"   => "",
-        "name"      => "wpghs_repository",
-        "help_text" => __("The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>benbalter/benbalter.github.com</code>. The repository should contain an initial commit.", WordPress_GitHub_Sync::$text_domain)
-      )
-    );
+		register_setting( WordPress_GitHub_Sync::$text_domain, 'wpghs_repository' );
+		add_settings_field( 'wpghs_repository', __( 'Repository', WordPress_GitHub_Sync::$text_domain ), array( &$this, 'field_callback' ), WordPress_GitHub_Sync::$text_domain, 'general', array(
+				'default'   => '',
+				'name'      => 'wpghs_repository',
+				'help_text' => __( 'The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>benbalter/benbalter.github.com</code>. The repository should contain an initial commit.', WordPress_GitHub_Sync::$text_domain )
+			)
+		);
 
-    register_setting( WordPress_GitHub_Sync::$text_domain, "wpghs_oauth_token" );
-    add_settings_field( "wpghs_oauth_token", __("Oauth Token", WordPress_GitHub_Sync::$text_domain), array(&$this, "field_callback"), WordPress_GitHub_Sync::$text_domain, "general", array(
-        "default"   => "",
-        "name"      => "wpghs_oauth_token",
-        "help_text" => __("A <a href='https://github.com/settings/tokens/new'>personal oauth token</a> with <code>public_repo</code> scope.", WordPress_GitHub_Sync::$text_domain)
-      )
-    );
+		register_setting( WordPress_GitHub_Sync::$text_domain, 'wpghs_oauth_token' );
+		add_settings_field( 'wpghs_oauth_token', __( 'Oauth Token', WordPress_GitHub_Sync::$text_domain ), array( &$this, 'field_callback' ), WordPress_GitHub_Sync::$text_domain, 'general', array(
+				'default'   => '',
+				'name'      => 'wpghs_oauth_token',
+				'help_text' => __( "A <a href='https://github.com/settings/tokens/new'>personal oauth token</a> with <code>public_repo</code> scope.", WordPress_GitHub_Sync::$text_domain )
+			)
+		);
 
-    register_setting( WordPress_GitHub_Sync::$text_domain, "wpghs_secret" );
-    add_settings_field( "wpghs_secret", __("Webhook Secret", WordPress_GitHub_Sync::$text_domain), array(&$this, "field_callback"), WordPress_GitHub_Sync::$text_domain, "general", array(
-        "default"   => "",
-        "name"      => "wpghs_secret",
-        "help_text" => __("The webhook's secret phrase.", WordPress_GitHub_Sync::$text_domain)
-      )
-    );
-  }
+		register_setting( WordPress_GitHub_Sync::$text_domain, 'wpghs_secret' );
+		add_settings_field( 'wpghs_secret', __( 'Webhook Secret', WordPress_GitHub_Sync::$text_domain ), array( &$this, 'field_callback' ), WordPress_GitHub_Sync::$text_domain, 'general', array(
+				'default'   => '',
+				'name'      => 'wpghs_secret',
+				'help_text' => __( "The webhook's secret phrase.", WordPress_GitHub_Sync::$text_domain )
+			)
+		);
+	}
 
-  /**
-   * Callback to render an individual options field
-   */
-  function field_callback($args) {
-    include dirname(dirname( __FILE__ )) . '/views/setting-field.php';
-  }
+	/**
+	 * Callback to render an individual options field
+	 */
+	public function field_callback($args) {
+		include dirname( dirname( __FILE__ ) ) . '/views/setting-field.php';
+	}
 
-  /**
-   * Displays settings messages from background processes
-   */
-  function section_callback() {
-    if ( get_current_screen()->id != "settings_page_" . WordPress_GitHub_Sync::$text_domain)
-      return;
+	/**
+	 * Displays settings messages from background processes
+	 */
+	public function section_callback() {
+		if ( 'settings_page_' . WordPress_GitHub_Sync::$text_domain !== get_current_screen()->id ) {
+			return;
+		}
 
-    if ('yes' === get_option( '_wpghs_export_started' )) { ?>
-      <div class="updated">
-        <p><?php _e( 'Export to GitHub started.', WordPress_GitHub_Sync::$text_domain ); ?></p>
-      </div><?php
-      delete_option( '_wpghs_export_started' );
-    }
+		if ( 'yes' === get_option( '_wpghs_export_started' ) ) { ?>
+			<div class="updated">
+				<p><?php _e( 'Export to GitHub started.', WordPress_GitHub_Sync::$text_domain ); ?></p>
+			</div><?php
+			delete_option( '_wpghs_export_started' );
+		}
 
-    if ( $message = get_option( '_wpghs_export_error'  ) ) { ?>
-      <div class="error">
-        <p><?php _e( 'Export to GitHub failed with error:', WordPress_GitHub_Sync::$text_domain ); ?> <?php echo esc_html( $message ) ;?></p>
-      </div><?php
-      delete_option( '_wpghs_export_error' );
-    }
+		if ( $message = get_option( '_wpghs_export_error' ) ) { ?>
+			<div class="error">
+				<p><?php _e( 'Export to GitHub failed with error:', WordPress_GitHub_Sync::$text_domain ); ?> <?php echo esc_html( $message );?></p>
+			</div><?php
+			delete_option( '_wpghs_export_error' );
+		}
 
-    if ( 'yes' === get_option( '_wpghs_export_complete'  ) ) { ?>
-      <div class="updated">
-        <p><?php _e( 'Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain ); ?></p>
-      </div><?php
-      delete_option( '_wpghs_export_complete' );
-    }
+		if ( 'yes' === get_option( '_wpghs_export_complete' ) ) { ?>
+			<div class="updated">
+				<p><?php _e( 'Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain );?></p>
+			</div><?php
+			delete_option( '_wpghs_export_complete' );
+		}
 
-  }
+	}
 
-  /**
-   * Add options menu to admin navbar
-   */
-  function add_admin_menu() {
-    add_options_page( __('WordPress <--> GitHub Sync', WordPress_GitHub_Sync::$text_domain), __('GitHub Sync', WordPress_GitHub_Sync::$text_domain), 'manage_options', WordPress_GitHub_Sync::$text_domain, array( &$this, 'settings_page' ) );
-  }
+	/**
+	 * Add options menu to admin navbar
+	 */
+	public function add_admin_menu() {
+		add_options_page( __( 'WordPress <--> GitHub Sync', WordPress_GitHub_Sync::$text_domain ), __( 'GitHub Sync', WordPress_GitHub_Sync::$text_domain ), 'manage_options', WordPress_GitHub_Sync::$text_domain, array( &$this, 'settings_page' ) );
+	}
 
-  /**
-   * Admin callback to trigger import/export because WordPress admin routing lol
-   */
-  function callback() {
-    global $wpghs;
+	/**
+	 * Admin callback to trigger import/export because WordPress admin routing lol
+	 */
+	public function callback() {
+		global $wpghs;
 
-    if ( !current_user_can( 'manage_options' ) )
-      return;
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-    if ( get_current_screen()->id != "settings_page_" . WordPress_GitHub_Sync::$text_domain)
-      return;
+		if ( 'settings_page_' . WordPress_GitHub_Sync::$text_domain !== get_current_screen()->id ) {
+			return;
+		}
 
-    if ( !isset($_GET['action'] ) )
-      return;
+		if ( ! isset($_GET['action'] ) ) {
+			return;
+		}
 
-    if ($_GET['action'] == "export")
-      $wpghs->start_export();
+		if ( 'export' === $_GET['action'] ) {
+			$wpghs->start_export();
+		}
 
-    if ($_GET['action'] == "import")
-      $wpghs->start_import();
-  }
+		if ( 'import' === $_GET['action'] ) {
+			$wpghs->start_import();
+		}
+	}
 }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -38,7 +38,7 @@ class WordPress_GitHub_Sync_Admin {
     add_settings_field( "wpghs_repository", __("Repository",WordPress_GitHub_Sync::$text_domain), array(&$this, "field_callback"), WordPress_GitHub_Sync::$text_domain, "general", array(
         "default"   => "",
         "name"      => "wpghs_repository",
-        "help_text" => __("The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>benbalter/benbalter.github.com</code>.", WordPress_GitHub_Sync::$text_domain)
+        "help_text" => __("The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>benbalter/benbalter.github.com</code>. The repository should contain an initial commit.", WordPress_GitHub_Sync::$text_domain)
       )
     );
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -121,5 +121,7 @@ class WordPress_GitHub_Sync_Admin {
     if ($_GET['action'] == "export")
       $wpghs->start_export();
 
+    if ($_GET['action'] == "import")
+      $wpghs->start_import();
   }
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -136,7 +136,7 @@ class WordPress_GitHub_Sync_Api {
     $sha = $this->last_commit_sha();
 
     if ( is_wp_error( $sha ) ) {
-      return $data;
+      return $sha;
     }
 
     return $this->get_commit( $sha );

--- a/lib/api.php
+++ b/lib/api.php
@@ -4,283 +4,283 @@
  */
 class WordPress_GitHub_Sync_Api {
 
-  /**
-   * Retrieves the blob data for a given sha
-   */
-  function get_blob($sha) {
-    if (! $this->oauth_token() || ! $this->repository()) {
-      return false;
-    }
+	/**
+	 * Retrieves the blob data for a given sha
+	 */
+	public function get_blob($sha) {
+		if ( ! $this->oauth_token() || ! $this->repository() ) {
+			return false;
+		}
 
-    return $this->call("GET", $this->blob_endpoint() . "/" . $sha);
-  }
+		return $this->call( 'GET', $this->blob_endpoint() . '/' . $sha );
+	}
 
-  /**
-   * Retrieves a tree by sha recursively from the GitHub API
-   */
-  function get_tree_recursive($sha) {
-    if (! $this->oauth_token() || ! $this->repository()) {
-      return false;
-    }
+	/**
+	 * Retrieves a tree by sha recursively from the GitHub API
+	 */
+	public function get_tree_recursive($sha) {
+		if ( ! $this->oauth_token() || ! $this->repository() ) {
+			return false;
+		}
 
-    $data = $this->call("GET", $this->tree_endpoint() . "/" . $sha . "?recursive=1");
+		$data = $this->call( 'GET', $this->tree_endpoint() . '/' . $sha . '?recursive=1' );
 
-    foreach ($data->tree as $index => $thing) {
-      // We need to remove the trees because
-      // the recursive tree includes both
-      // the subtrees as well the subtrees' blobs
-      if ( $thing->type === "tree" ) {
-        unset($data->tree[ $index ]);
-      }
-    }
+		foreach ( $data->tree as $index => $thing ) {
+			// We need to remove the trees because
+			// the recursive tree includes both
+			// the subtrees as well the subtrees' blobs
+			if ( 'tree' === $thing->type ) {
+				unset($data->tree[ $index ]);
+			}
+		}
 
-    return array_values($data->tree);
-  }
+		return array_values( $data->tree );
+	}
 
-  /**
-   * Retrieves a commit by sha from the GitHub API
-   */
-  function get_commit($sha) {
-    if (! $this->oauth_token() || ! $this->repository()) {
-      return false;
-    }
+	/**
+	 * Retrieves a commit by sha from the GitHub API
+	 */
+	public function get_commit($sha) {
+		if ( ! $this->oauth_token() || ! $this->repository() ) {
+			return false;
+		}
 
-    return $this->call("GET", $this->commit_endpoint() . "/" . $sha);
-  }
+		return $this->call( 'GET', $this->commit_endpoint() . '/' . $sha );
+	}
 
-  /**
-   * Retrieves the current master branch
-   */
-  function get_ref_master() {
-    if (! $this->oauth_token() || ! $this->repository()) {
-      return false;
-    }
+	/**
+	 * Retrieves the current master branch
+	 */
+	public function get_ref_master() {
+		if ( ! $this->oauth_token() || ! $this->repository() ) {
+			return false;
+		}
 
-    return $this->call("GET", $this->reference_endpoint());
-  }
+		return $this->call( 'GET', $this->reference_endpoint() );
+	}
 
-  /**
-   * Create the tree by a set of blob ids
-   */
-  function create_tree($tree) {
-    $body = array( 'tree' => $tree );
+	/**
+	 * Create the tree by a set of blob ids
+	 */
+	public function create_tree($tree) {
+		$body = array( 'tree' => $tree );
 
-    return $this->call("POST", $this->tree_endpoint(), $body);
-  }
+		return $this->call( 'POST', $this->tree_endpoint(), $body );
+	}
 
-  /**
-   * Create the commit from tree sha
-   *
-   * $sha - string   shasum for the tree for this commit
-   */
-  function create_commit($sha, $msg) {
-    $parent_sha = $this->last_commit_sha();
+	/**
+	 * Create the commit from tree sha
+	 *
+	 * $sha - string   shasum for the tree for this commit
+	 */
+	public function create_commit($sha, $msg) {
+		$parent_sha = $this->last_commit_sha();
 
-    if ( is_wp_error( $parent_sha ) ) {
-      return $parent_sha;
-    }
+		if ( is_wp_error( $parent_sha ) ) {
+			return $parent_sha;
+		}
 
-    $body = array(
-      "message" => $msg,
-      "author"  => $this->export_user(),
-      "tree"    => $sha,
-      "parents" => array( $parent_sha ),
-    );
+		$body = array(
+			'message' => $msg,
+			'author'  => $this->export_user(),
+			'tree'    => $sha,
+			'parents' => array( $parent_sha ),
+		);
 
-    return $this->call("POST", $this->commit_endpoint(), $body);
-  }
+		return $this->call( 'POST', $this->commit_endpoint(), $body );
+	}
 
-  /**
-   * Updates the master branch to point to the new commit
-   *
-   * $sha - string   shasum for the commit for the master branch
-   */
-  function set_ref($sha) {
-    $body = array(
-      'sha' => $sha,
-    );
+	/**
+	 * Updates the master branch to point to the new commit
+	 *
+	 * $sha - string   shasum for the commit for the master branch
+	 */
+	public function set_ref($sha) {
+		$body = array(
+			'sha' => $sha,
+		);
 
-    return $this->call("POST", $this->reference_endpoint(), $body);
-  }
+		return $this->call( 'POST', $this->reference_endpoint(), $body );
+	}
 
-  /**
-   * Retrieves the recursive tree for the master branch
-   */
-  function last_tree_recursive() {
-    $sha = $this->last_tree_sha();
+	/**
+	 * Retrieves the recursive tree for the master branch
+	 */
+	public function last_tree_recursive() {
+		$sha = $this->last_tree_sha();
 
-    if ( is_wp_error( $sha ) ) {
-      return $sha;
-    }
+		if ( is_wp_error( $sha ) ) {
+			return $sha;
+		}
 
-    return $this->get_tree_recursive( $sha );
-  }
+		return $this->get_tree_recursive( $sha );
+	}
 
-  /**
-   * Retrieves the sha for the last tree
-   */
-  function last_tree_sha() {
-    $data = $this->last_commit();
+	/**
+	 * Retrieves the sha for the last tree
+	 */
+	public function last_tree_sha() {
+		$data = $this->last_commit();
 
-    if ( is_wp_error( $data ) ) {
-      return $data;
-    }
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
 
-    return $data->tree->sha;
-  }
+		return $data->tree->sha;
+	}
 
-  /**
-   * Retrieve the last commit in the repository
-   */
-  function last_commit() {
-    $sha = $this->last_commit_sha();
+	/**
+	 * Retrieve the last commit in the repository
+	 */
+	public function last_commit() {
+		$sha = $this->last_commit_sha();
 
-    if ( is_wp_error( $sha ) ) {
-      return $sha;
-    }
+		if ( is_wp_error( $sha ) ) {
+			return $sha;
+		}
 
-    return $this->get_commit( $sha );
-  }
+		return $this->get_commit( $sha );
+	}
 
-  /**
-   * Retrieve the sha for the latest commit
-   */
-  function last_commit_sha() {
-    $data = $this->get_ref_master();
+	/**
+	 * Retrieve the sha for the latest commit
+	 */
+	public function last_commit_sha() {
+		$data = $this->get_ref_master();
 
-    if ( is_wp_error( $data ) ) {
-      return $data;
-    }
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
 
-    return $data->object->sha;
-  }
+		return $data->object->sha;
+	}
 
-  /**
-   * Calls the content API to get the post's contents and metadata
-   *
-   * Returns Object the response from the API
-   */
-  function remote_contents($post) {
-    return $this->call("GET", $this->content_endpoint() . $post->github_path());
-  }
+	/**
+	 * Calls the content API to get the post's contents and metadata
+	 *
+	 * Returns Object the response from the API
+	 */
+	public function remote_contents($post) {
+		return $this->call( 'GET', $this->content_endpoint() . $post->github_path() );
+	}
 
-  /**
-   * Generic GitHub API interface and response handler
-   */
-  function call($method, $endpoint, $body = array()) {
-    $args = array(
-      "method"  => $method,
-      "headers" => array(
-        "Authorization" => "token " . $this->oauth_token()
-      ),
-      "body"    => json_encode($body)
-    );
+	/**
+	 * Generic GitHub API interface and response handler
+	 */
+	public function call($method, $endpoint, $body = array()) {
+		$args = array(
+			'method'  => $method,
+			'headers' => array(
+				'Authorization' => 'token ' . $this->oauth_token()
+			),
+			'body'    => json_encode( $body )
+		);
 
-    $response = wp_remote_request( $endpoint, $args );
-    $status = wp_remote_retrieve_header( $response, 'status' );
-    $body = json_decode(wp_remote_retrieve_body( $response ) );
+		$response = wp_remote_request( $endpoint, $args );
+		$status = wp_remote_retrieve_header( $response, 'status' );
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
 
-    if ( "2" !== substr($status, 0, 1) && "3" !== substr($status, 0, 1)  ) {
-      return new WP_Error( $status, $body->message );
-    }
+		if ( '2' !== substr( $status, 0, 1 ) && '3' !== substr( $status, 0, 1 )  ) {
+			return new WP_Error( $status, $body->message );
+		}
 
-    return $body;
-  }
+		return $body;
+	}
 
-  /**
-   * Get the data for the current user
-   */
-  function export_user() {
-    if ( $user_id = get_option( '_wpghs_export_user_id' ) ) {
-      delete_option( '_wpghs_export_user_id' );
-    } else {
-      $user_id = get_current_user_id();
-    }
+	/**
+	 * Get the data for the current user
+	 */
+	public function export_user() {
+		if ( $user_id = get_option( '_wpghs_export_user_id' ) ) {
+			delete_option( '_wpghs_export_user_id' );
+		} else {
+			$user_id = get_current_user_id();
+		}
 
-    $user = get_userdata($user_id);
+		$user = get_userdata( $user_id );
 
-    if (!$user) {
-      return array();
-    }
+		if ( ! $user ) {
+			return array();
+		}
 
-    return array(
-      'name'  => $user->display_name,
-      'email' => $user->user_email,
-    );
-  }
+		return array(
+			'name'  => $user->display_name,
+			'email' => $user->user_email,
+		);
+	}
 
-  /**
-   * Returns the repository to sync with
-   */
-  function repository() {
-    return get_option( "wpghs_repository" );
-  }
+	/**
+	 * Returns the repository to sync with
+	 */
+	public function repository() {
+		return get_option( 'wpghs_repository' );
+	}
 
-  /**
-   * Returns the user's oauth token
-   */
-  function oauth_token() {
-    return get_option( "wpghs_oauth_token" );
-  }
+	/**
+	 * Returns the user's oauth token
+	 */
+	public function oauth_token() {
+		return get_option( 'wpghs_oauth_token' );
+	}
 
-  /**
-   * Returns the GitHub host to sync with (for GitHub Enterprise support)
-   */
-  function api_base() {
-    return get_option( "wpghs_host" );
-  }
+	/**
+	 * Returns the GitHub host to sync with (for GitHub Enterprise support)
+	 */
+	public function api_base() {
+		return get_option( 'wpghs_host' );
+	}
 
-  /**
-   * API endpoint for the master branch reference
-   */
-  function reference_endpoint() {
-    $url = $this->api_base() . "/repos/";
-    $url = $url . $this->repository() . "/git/refs/heads/master";
+	/**
+	 * API endpoint for the master branch reference
+	 */
+	public function reference_endpoint() {
+		$url = $this->api_base() . '/repos/';
+		$url = $url . $this->repository() . '/git/refs/heads/master';
 
-    return $url;
-  }
+		return $url;
+	}
 
-  /**
-   * Api to get and create commits
-   */
-  function commit_endpoint() {
-    $url = $this->api_base() . "/repos/";
-    $url = $url . $this->repository() . "/git/commits";
+	/**
+	 * Api to get and create commits
+	 */
+	public function commit_endpoint() {
+		$url = $this->api_base() . '/repos/';
+		$url = $url . $this->repository() . '/git/commits';
 
-    return $url;
-  }
+		return $url;
+	}
 
-  /**
-   * Api to get and create trees
-   */
-  function tree_endpoint() {
-    $url = $this->api_base() . "/repos/";
-    $url = $url . $this->repository() . "/git/trees";
+	/**
+	 * Api to get and create trees
+	 */
+	public function tree_endpoint() {
+		$url = $this->api_base() . '/repos/';
+		$url = $url . $this->repository() . '/git/trees';
 
-    return $url;
-  }
+		return $url;
+	}
 
-  /**
-   * Builds the proper blob API endpoint for a given post
-   *
-   * Returns String the relative API call path
-   */
-  function blob_endpoint() {
-    $url = $this->api_base() . "/repos/";
-    $url = $url . $this->repository() . "/git/blobs";
+	/**
+	 * Builds the proper blob API endpoint for a given post
+	 *
+	 * Returns String the relative API call path
+	 */
+	public function blob_endpoint() {
+		$url = $this->api_base() . '/repos/';
+		$url = $url . $this->repository() . '/git/blobs';
 
-    return $url;
-  }
+		return $url;
+	}
 
-  /**
-   * Builds the proper content API endpoint for a given post
-   *
-   * Returns String the relative API call path
-   */
-  function content_endpoint() {
-    $url = $this->api_base() . "/repos/";
-    $url = $url . $this->repository() . "/contents/";
+	/**
+	 * Builds the proper content API endpoint for a given post
+	 *
+	 * Returns String the relative API call path
+	 */
+	public function content_endpoint() {
+		$url = $this->api_base() . '/repos/';
+		$url = $url . $this->repository() . '/contents/';
 
-    return $url;
-  }
+		return $url;
+	}
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * Interfaces with the GitHub API
+ */
+class WordPress_GitHub_Sync_Api {
+
+  /**
+   * Retrieves the blob data for a given sha
+   */
+  function get_blob($sha) {
+    if (! $this->oauth_token() || ! $this->repository()) {
+      return false;
+    }
+
+    $blob = $this->call("GET", $this->blob_endpoint() . "/" . $sha);
+
+    return $blob;
+  }
+
+  /**
+   * Create the tree by a set of blob ids
+   */
+  function create_tree($tree) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $body = array( 'tree' => $tree );
+    $data = $this->call("POST", $this->tree_endpoint(), $body);
+
+    if ($data && isset($data->sha) && !isset($data->errors)) {
+      update_option( '_wpghs_last_tree_sha', $data->sha );
+      return $data;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Create the commit from tree sha
+   *
+   * $sha - string   shasum for the tree for this commit
+   */
+  function create_commit($sha) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $body = array(
+      "message" => "Full export from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ")",
+      "author"  => $this->export_user(),
+      "tree"    => $sha,
+      "parents" => array( $this->last_commit_sha() ),
+    );
+
+    $data = $this->call("POST", $this->commit_endpoint(), $body);
+
+    if ($data && isset($data->sha) && !isset($data->errors)) {
+      return $data->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Updates the master branch to point to the new commit
+   *
+   * $sha - string   shasum for the commit for the master branch
+   */
+  function set_ref($sha) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $body = array(
+      'sha' => $sha,
+    );
+
+    $data = $this->call("POST", $this->reference_endpoint(), $body);
+
+    if ($data && isset($data->object) && !isset($data->errors)) {
+      update_option( '_wpghs_last_commit_sha', $data->object->sha );
+      return $data->object->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Push the post to GitHub
+   */
+  function push($post) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $body = array(
+      "message" => "Syncing " . $post->github_path() . " from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ")",
+      "content" => base64_encode($post->github_content()),
+      "author"  => $post->last_modified_author(),
+      "sha"     => $post->sha()
+    );
+
+    $data = $this->call("PUT", $this->content_endpoint() . $post->github_path(), $body );
+
+    if ($data && isset($data->content) && !isset($data->errors)) {
+      $sha = $data->content->sha;
+      add_post_meta( $post->id, '_sha', $sha, true ) || update_post_meta( $post->id, '_sha', $sha );
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+
+    return true;
+  }
+
+  /**
+   * Pull the post from GitHub
+   */
+  function pull($post) {
+    $data = $this->remote_contents($post);
+    $content = base64_decode($data->content);
+
+    // Break out meta, if present
+    preg_match( "/(^---(.*)---$)?(.*)/ms", $content, $matches );
+
+    $body = array_pop( $matches );
+
+    if (count($matches) == 3) {
+      $meta = spyc_load($matches[2]);
+      if ($meta['permalink']) $meta['permalink'] = str_replace(home_url(), '', get_permalink($meta['permalink']));
+    } else {
+      $meta = array();
+    }
+
+    if ( function_exists( 'wpmarkdown_markdown_to_html' ) ) {
+      $body = wpmarkdown_markdown_to_html( $body );
+    }
+
+    wp_update_post( array_merge( $meta, array(
+        "ID"           => $post->id,
+        "post_content" => $body
+      ))
+    );
+  }
+
+  /**
+   * Delete a post from GitHub
+   */
+  function delete($post) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $body = array(
+      "message" => "Deleting " . $post->github_path() . " via WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ")",
+      "author"  => $post->last_modified_author(),
+      "sha"     => $post->sha()
+    );
+
+    $this->call("DELETE", $this->content_endpoint() . $post->github_path(), $body);
+  }
+
+  /**
+   * Retrieves the recursive tree for the master branch
+   */
+  function last_tree_recursive() {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $data = $this->call("GET", $this->tree_endpoint() . "/" . $this->last_tree_sha() . "?recursive=1");
+
+    return $data->tree;
+  }
+
+  /**
+   * Retrieves the sha for the last tree
+   *
+   * Makes a live call if not saved
+   */
+  function last_tree_sha() {
+    global $wpghs;
+
+    $sha = get_option( "_wpghs_last_tree_sha" );
+
+    if ( !empty($sha) ) {
+      return $sha;
+    }
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $data = $this->call("GET", $this->commit_endpoint() . "/" . $this->last_commit_sha() );
+
+    if ($data && isset($data->tree) && !isset($data->errors)) {
+      update_option( "_wpghs_last_tree_sha", $data->tree->sha );
+      return $data->tree->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Retrieve the sha for the latest commit
+   *
+   * Will make a live call if not found
+   */
+  function last_commit_sha() {
+    global $wpghs;
+
+    $sha = get_option( "_wpghs_last_commit_sha" );
+
+    if ( !empty($sha) ) {
+      return $sha;
+    }
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    $data = $this->call("GET", $this->reference_endpoint());
+    $sha = $data->object->sha;
+
+    update_option( "_wpghs_last_commit_sha", $sha );
+    return $sha;
+  }
+
+  /**
+   * Calls the content API to get the post's contents and metadata
+   *
+   * Returns Object the response from the API
+   */
+  function remote_contents($post) {
+    global $wpghs;
+
+    if (! $this->oauth_token() || ! $this->repository() || $wpghs->push_lock) {
+      return false;
+    }
+
+    return $this->call("GET", $this->content_endpoint() . $post->github_path());
+  }
+
+  /**
+   * Generic GitHub API interface and response handler
+   *
+   * @todo Error handle the data response
+   */
+  function call($method, $endpoint, $body = array()) {
+    $args = array(
+      "method"  => $method,
+      "headers" => array(
+        "Authorization" => "token " . $this->oauth_token()
+      ),
+      "body"    => json_encode($body)
+    );
+
+    $response = wp_remote_request( $endpoint, $args );
+
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+
+    return $data;
+  }
+
+  /**
+   * Get the data for the current user
+   *
+   * @todo check if object, set some defaults if not
+   */
+  function export_user() {
+    $user_id = get_option( '_wpghs_export_user_id' );
+    delete_option( '_wpghs_export_user_id' );
+
+    $user = get_userdata($user_id);
+
+    if (!$user) {
+      return array();
+    }
+
+    return array(
+      'name'  => $user->display_name,
+      'email' => $user->user_email,
+    );
+  }
+
+  /**
+   * Returns the repository to sync with
+   */
+  function repository() {
+    return get_option( "wpghs_repository" );
+  }
+
+  /**
+   * Returns the user's oauth token
+   */
+  function oauth_token() {
+    return get_option( "wpghs_oauth_token" );
+  }
+
+  /**
+   * Returns the GitHub host to sync with (for GitHub Enterprise support)
+   */
+  function api_base() {
+    return get_option( "wpghs_host" );
+  }
+
+  /**
+   * Api to update the master branch's reference
+   */
+  function reference_endpoint() {
+    $url = $this->api_base() . "/repos/";
+    $url = $url . $this->repository() . "/git/refs/heads/master";
+
+    return $url;
+  }
+
+  /**
+   * Api to get and create commits
+   */
+  function commit_endpoint() {
+    $url = $this->api_base() . "/repos/";
+    $url = $url . $this->repository() . "/git/commits";
+
+    return $url;
+  }
+
+  /**
+   * Api to get and create trees
+   */
+  function tree_endpoint() {
+    $url = $this->api_base() . "/repos/";
+    $url = $url . $this->repository() . "/git/trees";
+
+    return $url;
+  }
+
+  /**
+   * Builds the proper blob API endpoint for a given post
+   *
+   * Returns String the relative API call path
+   */
+  function blob_endpoint() {
+    $url = $this->api_base() . "/repos/";
+    $url = $url . $this->repository() . "/git/blobs";
+
+    return $url;
+  }
+
+  /**
+   * Builds the proper content API endpoint for a given post
+   *
+   * Returns String the relative API call path
+   */
+  function content_endpoint() {
+    $url = $this->api_base() . "/repos/";
+    $url = $url . $this->repository() . "/contents/";
+
+    return $url;
+  }
+}

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -35,7 +35,12 @@ class WordPress_GitHub_Sync_CLI {
 
     if ( $post_id === 'all' ) {
       update_option( '_wpghs_export_user_id', $user_id );
-      $this->controller->cli_start();
+      $this->controller->process();
+    } elseif ( is_numeric($post_id) ) {
+      $post = new WordPress_GitHub_Sync_Post($post_id);
+      $this->controller->api->push($post);
+    } else {
+      WP_CLI::error( __("Invalid Post ID", WordPress_GitHub_Sync::$text_domain) );
     }
   }
 }

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * WP_CLI Commands
+ */
+class WordPress_GitHub_Sync_CLI {
+
+  /**
+   * Wire up controller object on init
+   */
+  function __construct() {
+    $this->controller = new WordPress_GitHub_Sync_Controller;
+  }
+
+  /**
+   * Exports an individual post
+   * all your posts to GitHub
+   *
+   * ## OPTIONS
+   *
+   * <post_id|all>
+   * : The post ID to export or 'all' for full site
+   *
+   * <user_id>
+   * : The user ID you'd like to save the commit as
+   *
+   * ## EXAMPLES
+   *
+   *     wp wpghs export all 1
+   *     wp wpghs export 1 1
+   *
+   * @synopsis <post_id|all> <user_id>
+   */
+  function export( $args, $assoc_args ) {
+    list( $post_id, $user_id ) = $args;
+
+    if ( $post_id === 'all' ) {
+      update_option( '_wpghs_export_user_id', $user_id );
+      $this->controller->cli_start();
+    }
+  }
+}

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -49,4 +49,33 @@ class WordPress_GitHub_Sync_CLI {
       WP_CLI::error( __("Invalid post ID", WordPress_GitHub_Sync::$text_domain) );
     }
   }
+
+  /**
+   * Imports the post in your GitHub repo
+   * into your WordPress blog
+   *
+   * ## OPTIONS
+   *
+   * <user_id>
+   * : The user ID you'd like to save the commit as
+   *
+   * ## EXAMPLES
+   *
+   *     wp wpghs import 1
+   *
+   * @synopsis <user_id>
+   */
+  function import( $args, $assoc_args ) {
+    list( $user_id ) = $args;
+
+    if ( !is_numeric($user_id) ) {
+      WP_CLI::error( __("Invalid user ID", WordPress_GitHub_Sync::$text_domain) );
+    }
+
+    update_option( '_wpghs_export_user_id', (int) $user_id );
+
+    WP_CLI::line( __( 'Starting import from GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+
+    $this->controller->import_master();
+  }
 }

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -33,14 +33,20 @@ class WordPress_GitHub_Sync_CLI {
   function export( $args, $assoc_args ) {
     list( $post_id, $user_id ) = $args;
 
+    if ( !is_numeric($user_id) ) {
+      WP_CLI::error( __("Invalid user ID", WordPress_GitHub_Sync::$text_domain) );
+    }
+
+    update_option( '_wpghs_export_user_id', (int) $user_id );
+
     if ( $post_id === 'all' ) {
-      update_option( '_wpghs_export_user_id', $user_id );
-      $this->controller->process();
+      WP_CLI::line( __( 'Starting full export to GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+      $this->controller->export_all();
     } elseif ( is_numeric($post_id) ) {
-      $post = new WordPress_GitHub_Sync_Post($post_id);
-      $this->controller->api->push($post);
+      WP_CLI::line( __( 'Exporting post ID to GitHub: ', WordPress_GitHub_Sync::$text_domain ). $post_id );
+      $this->controller->export_post((int) $post_id);
     } else {
-      WP_CLI::error( __("Invalid Post ID", WordPress_GitHub_Sync::$text_domain) );
+      WP_CLI::error( __("Invalid post ID", WordPress_GitHub_Sync::$text_domain) );
     }
   }
 }

--- a/lib/cli.php
+++ b/lib/cli.php
@@ -4,78 +4,84 @@
  */
 class WordPress_GitHub_Sync_CLI {
 
-  /**
-   * Wire up controller object on init
-   */
-  function __construct() {
-    $this->controller = new WordPress_GitHub_Sync_Controller;
-  }
+	/**
+	 * Controller object
+	 * @var WordPress_GitHub_Sync_Controller
+	 */
+	public $controller;
 
-  /**
-   * Exports an individual post
-   * all your posts to GitHub
-   *
-   * ## OPTIONS
-   *
-   * <post_id|all>
-   * : The post ID to export or 'all' for full site
-   *
-   * <user_id>
-   * : The user ID you'd like to save the commit as
-   *
-   * ## EXAMPLES
-   *
-   *     wp wpghs export all 1
-   *     wp wpghs export 1 1
-   *
-   * @synopsis <post_id|all> <user_id>
-   */
-  function export( $args, $assoc_args ) {
-    list( $post_id, $user_id ) = $args;
+	/**
+	 * Wire up controller object on init
+	 */
+	public function __construct() {
+		$this->controller = new WordPress_GitHub_Sync_Controller;
+	}
 
-    if ( !is_numeric($user_id) ) {
-      WP_CLI::error( __("Invalid user ID", WordPress_GitHub_Sync::$text_domain) );
-    }
+	/**
+	 * Exports an individual post
+	 * all your posts to GitHub
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id|all>
+	 * : The post ID to export or 'all' for full site
+	 *
+	 * <user_id>
+	 * : The user ID you'd like to save the commit as
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wpghs export all 1
+	 *     wp wpghs export 1 1
+	 *
+	 * @synopsis <post_id|all> <user_id>
+	 */
+	public function export( $args, $assoc_args ) {
+		list( $post_id, $user_id ) = $args;
 
-    update_option( '_wpghs_export_user_id', (int) $user_id );
+		if ( ! is_numeric( $user_id ) ) {
+			WP_CLI::error( __( 'Invalid user ID', WordPress_GitHub_Sync::$text_domain ) );
+		}
 
-    if ( $post_id === 'all' ) {
-      WP_CLI::line( __( 'Starting full export to GitHub.', WordPress_GitHub_Sync::$text_domain ) );
-      $this->controller->export_all();
-    } elseif ( is_numeric($post_id) ) {
-      WP_CLI::line( __( 'Exporting post ID to GitHub: ', WordPress_GitHub_Sync::$text_domain ). $post_id );
-      $this->controller->export_post((int) $post_id);
-    } else {
-      WP_CLI::error( __("Invalid post ID", WordPress_GitHub_Sync::$text_domain) );
-    }
-  }
+		update_option( '_wpghs_export_user_id', (int) $user_id );
 
-  /**
-   * Imports the post in your GitHub repo
-   * into your WordPress blog
-   *
-   * ## OPTIONS
-   *
-   * <user_id>
-   * : The user ID you'd like to save the commit as
-   *
-   * ## EXAMPLES
-   *
-   *     wp wpghs import 1
-   *
-   * @synopsis <user_id>
-   */
-  function import( $args, $assoc_args ) {
-    list( $user_id ) = $args;
+		if ( 'all' === $post_id ) {
+			WP_CLI::line( __( 'Starting full export to GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+			$this->controller->export_all();
+		} elseif ( is_numeric( $post_id ) ) {
+			WP_CLI::line( __( 'Exporting post ID to GitHub: ', WordPress_GitHub_Sync::$text_domain ). $post_id );
+			$this->controller->export_post( (int) $post_id );
+		} else {
+			WP_CLI::error( __( 'Invalid post ID', WordPress_GitHub_Sync::$text_domain ) );
+		}
+	}
 
-    if ( !is_numeric($user_id) ) {
-      WP_CLI::error( __("Invalid user ID", WordPress_GitHub_Sync::$text_domain) );
-    }
+	/**
+	 * Imports the post in your GitHub repo
+	 * into your WordPress blog
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user_id>
+	 * : The user ID you'd like to save the commit as
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wpghs import 1
+	 *
+	 * @synopsis <user_id>
+	 */
+	public function import( $args, $assoc_args ) {
+		list( $user_id ) = $args;
 
-    update_option( '_wpghs_export_user_id', (int) $user_id );
+		if ( ! is_numeric( $user_id ) ) {
+			WP_CLI::error( __( 'Invalid user ID', WordPress_GitHub_Sync::$text_domain ) );
+		}
 
-    WP_CLI::line( __( 'Starting import from GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+		update_option( '_wpghs_export_user_id', (int) $user_id );
 
-    $this->controller->import_master();
-  }
+		WP_CLI::line( __( 'Starting import from GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+
+		$this->controller->import_master();
+	}
 }

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * The controller object which manages
+ */
+class WordPress_GitHub_Sync_Controller {
+
+  /**
+   * Instantiates a new Controller object
+   *
+   * $posts - array of post IDs to export
+   */
+  function __construct() {}
+
+  /**
+   * Sets up and begins the export process
+   */
+  function start() {
+    wp_schedule_single_event(time(), 'wpghs_export');
+    WordPress_GitHub_Sync::write_log( __( "Starting export to GitHub", WordPress_GitHub_Sync::$text_domain ) );
+    spawn_cron();
+    update_option( '_wpghs_export_started', 'yes' );
+  }
+
+  /**
+   * Export posts
+   *
+   * Runs as cronjob
+   */
+  function process() {
+    $i = 0;
+    $this->get_data();
+
+    while(!empty($this->posts) && $i < 50) {
+      $post_id = array_shift($this->posts);
+      WordPress_GitHub_Sync::write_log( __("Exporting Post ID: ", WordPress_GitHub_Sync::$text_domain ) . $post_id );
+
+      $post = new WordPress_GitHub_Sync_Post($post_id);
+      $result = $post->push();
+
+      if ( is_wp_error( $result ) ) {
+        array_unshift($this->posts, $post_id);
+        $this->error($result);
+        die();
+      }
+
+      usleep(500000);
+      $this->blobs[] = $result;
+
+      $i++;
+    }
+
+    if (!empty($this->posts)) {
+      $this->handoff();
+    } else {
+      $this->success();
+    }
+
+    die();
+  }
+
+  /**
+   * Takes the posts array and hands it off to a new process
+   */
+  function handoff() {
+    $nonce = wp_hash( time() );
+    update_option( '_wpghs_export_nonce', $nonce );
+
+    $this->save_data();
+
+    // Request page that will continue export
+    wp_remote_post( add_query_arg( 'github', 'sync', site_url( 'index.php' ) ), array(
+      'body' => array(
+        'nonce' => $nonce,
+      ),
+      'blocking' => false,
+    ) );
+  }
+
+  /**
+   * Writes out the results of a successful export
+   */
+  function success() {
+    update_option( '_wpghs_export_complete', 'yes' );
+    delete_option( '_wpghs_posts_to_export' );
+    delete_option( '_wpghs_exported_blobs' );
+    WordPress_GitHub_Sync::write_log( __('Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain ) );
+  }
+
+  /**
+   * Writes out the results of an error and saves the data
+   */
+  function error($result) {
+    update_option( '_wpghs_export_error', $result->get_error_message() );
+    WordPress_GitHub_Sync::write_log( __("Error exporting to GitHub. Error: ", WordPress_GitHub_Sync::$text_domain ) . $result->get_error_message() );
+
+    $this->save_data();
+  }
+
+  /**
+   * Retrieves the object's data from the database
+   */
+  function get_data() {
+    global $wpdb;
+    $posts = get_option( '_wpghs_posts_to_export' );
+
+    if ( ! $posts ) {
+      $posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ('post', 'page' )" );
+    }
+
+    $this->posts = $posts;
+    WordPress_GitHub_Sync::write_log( __( "Number of retrieved posts: ", WordPress_GitHub_Sync::$text_domain ) . count($this->posts) );
+
+    $blobs = get_option( '_wpghs_exported_blobs' );
+
+    if ( ! $blobs ) {
+      $blobs = array();
+    }
+
+    $this->blobs = $blobs;
+    WordPress_GitHub_Sync::write_log( __( "Number of retrived blobs: ", WordPress_GitHub_Sync::$text_domain ) . count($this->blobs) );
+  }
+
+  /**
+   * Save the object's data to the database
+   */
+  function save_data() {
+    update_option( '_wpghs_posts_to_export', $this->posts );
+    update_option( '_wpghs_exported_blobs', $this->blobs );
+    WordPress_GitHub_Sync::write_log( __( "Number of saved posts: ", WordPress_GitHub_Sync::$text_domain ) . count($this->posts) );
+    WordPress_GitHub_Sync::write_log( __( "Number of saved blobs: ", WordPress_GitHub_Sync::$text_domain ) . count($this->blobs) );
+  }
+}

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -35,7 +35,7 @@ class WordPress_GitHub_Sync_Controller {
       WordPress_GitHub_Sync::write_log( __("Exporting Post ID: ", WordPress_GitHub_Sync::$text_domain ) . $post_id );
 
       $post = new WordPress_GitHub_Sync_Post($post_id);
-      $result = $post->push();
+      $result = $post->push_blob();
 
       if ( is_wp_error( $result ) ) {
         array_unshift($this->posts, $post_id);
@@ -44,7 +44,7 @@ class WordPress_GitHub_Sync_Controller {
       }
 
       usleep(500000);
-      $this->blobs[] = $result;
+      $this->blobs[] = $post_id;
 
       $i++;
     }
@@ -52,7 +52,7 @@ class WordPress_GitHub_Sync_Controller {
     if (!empty($this->posts)) {
       $this->handoff();
     } else {
-      $this->success();
+      $this->finalize();
     }
 
     die();
@@ -74,6 +74,285 @@ class WordPress_GitHub_Sync_Controller {
       ),
       'blocking' => false,
     ) );
+  }
+
+  /**
+   * After all the blobs are saved,
+   * create the tree, commit, and adjust master ref
+   */
+  function finalize() {
+    WordPress_GitHub_Sync::write_log(__( 'Creating the tree.', WordPress_GitHub_Sync::$text_domain ));
+    $tree_sha = $this->create_tree();
+
+    if ( is_wp_error( $tree_sha ) ) {
+      $this->error($tree_sha);
+      die();
+    }
+
+    WordPress_GitHub_Sync::write_log(__( 'Creating the commit.', WordPress_GitHub_Sync::$text_domain ));
+    $commit_sha = $this->create_commit($tree_sha);
+
+    if ( is_wp_error( $commit_sha ) ) {
+      $this->error($commit_sha);
+      die();
+    }
+
+    WordPress_GitHub_Sync::write_log(__( 'Setting the master branch to our new commit.', WordPress_GitHub_Sync::$text_domain ));
+    $ref_sha = $this->set_ref($commit_sha);
+
+    if ( is_wp_error( $ref_sha ) ) {
+      $this->error($ref_sha);
+      die();
+    }
+
+    $this->success();
+  }
+
+  /**
+   * Create the tree from the saved blobs
+   */
+  function create_tree() {
+    global $wpghs;
+
+    if ($wpghs->push_lock)
+      return false;
+
+    $tree = array();
+
+    foreach ($this->blobs as $post_id) {
+      $post = new WordPress_GitHub_Sync_Post($post_id);
+      $tree[] = array(
+        "path" => $post->github_path(),
+        "mode" => "100644",
+        "type" => "blob",
+        "sha"  => $post->sha(),
+      );
+    }
+
+    $args = array(
+      "method"  => "POST",
+      "headers" => array(
+          "Authorization" => "token " . $wpghs->oauth_token()
+        ),
+      "body"    => json_encode( array(
+          'tree' => $tree,
+          'base_tree' => $this->last_tree_sha(),
+        )
+      )
+    );
+
+    $response = wp_remote_request( $this->tree_endpoint(), $args );
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+
+    if ($data && isset($data->sha) && !isset($data->errors)) {
+      return $data->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Retrieves the sha for the last tree
+   *
+   * Makes a live call if not saved
+   */
+  function last_tree_sha() {
+    global $wpghs;
+
+    $sha = get_option( "_wpghs_last_tree_sha" );
+
+    if ( !empty($sha) ) {
+      return $sha;
+    }
+
+    $response = wp_remote_get( $this->commit_endpoint() . "/" . $this->last_commit_sha(), array(
+      "headers" => array(
+        "Authorization" => "token " . $wpghs->oauth_token()
+        )
+      )
+    );
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+
+    if ($data && isset($data->tree) && !isset($data->errors)) {
+      update_option( "_wpghs_last_tree_sha", $data->tree->sha );
+      return $data->tree->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Create the commit from tree sha
+   *
+   * $sha - string   shasum for the tree for this commit
+   */
+  function create_commit($sha) {
+    global $wpghs;
+
+    if ($wpghs->push_lock)
+      return false;
+
+    $commit = array(
+      "message" => "Full export from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ")",
+      "author"  => $this->export_user(),
+      "tree"    => $sha,
+      "parents" => array( $this->last_commit_sha() ),
+    );
+
+    $args = array(
+      "method"  => "POST",
+      "headers" => array(
+          "Authorization" => "token " . $wpghs->oauth_token()
+        ),
+      "body"    => json_encode( $commit )
+    );
+
+    $response = wp_remote_request( $this->commit_endpoint(), $args );
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+
+    if ($data && isset($data->sha) && !isset($data->errors)) {
+      return $data->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Updates the master branch to point to the new commit
+   *
+   * $sha - string   shasum for the commit for the master branch
+   */
+  function set_ref($sha) {
+    global $wpghs;
+
+    if ($wpghs->push_lock)
+      return false;
+
+    $args = array(
+      "method"  => "POST",
+      "headers" => array(
+          "Authorization" => "token " . $wpghs->oauth_token()
+        ),
+      "body"    => json_encode( array(
+          'sha' => $sha,
+        )
+      )
+    );
+
+    $response = wp_remote_request( $this->master_reference_endpoint(), $args );
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+
+    if ($data && isset($data->object) && !isset($data->errors)) {
+      update_option( '_wpghs_last_commit_sha', $data->object->sha );
+      return $data->object->sha;
+    } else {
+      // save a message and quit
+      if ( isset($data->message) ) {
+        $error = new WP_Error( 'wpghs_error_message', $data->message );
+      } elseif( empty($data) ) {
+        $error = new WP_Error( 'wpghs_error_message', __( 'No body returned', WordPress_GitHub_Sync::$text_domain ) );
+      }
+
+      return $error;
+    }
+  }
+
+  /**
+   * Get the data for the current user
+   */
+  function export_user() {
+    $user_id = get_option( '_wpghs_export_user_id' );
+    delete_option( '_wpghs_export_user_id' );
+
+    $user = get_user_by( 'id', intval($user_id) );
+
+    return array(
+      'name'  => $user->display_name,
+      'email' => $user->user_email,
+    );
+  }
+
+  /**
+   * Retrieve the sha for the latest commit
+   *
+   * Will make a live call if not found
+   */
+  function last_commit_sha() {
+    global $wpghs;
+
+    $sha = get_option( "_wpghs_last_commit_sha" );
+
+    if ( !empty($sha) ) {
+      return $sha;
+    }
+
+    $response = wp_remote_get( $this->master_reference_endpoint(), array(
+      "headers" => array(
+        "Authorization" => "token " . $wpghs->oauth_token()
+        )
+      )
+    );
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body);
+    $sha = $data->object->sha;
+
+    update_option( "_wpghs_last_commit_sha", $sha );
+    return $sha;
+  }
+
+  /**
+   * Api to update the master branch's reference
+   */
+  function master_reference_endpoint() {
+    global $wpghs;
+    $url = $wpghs->api_base() . "/repos/";
+    $url = $url . $wpghs->repository() . "/git/refs/heads/master";
+    return $url;
+  }
+
+  /**
+   * Api to get and create commits
+   */
+  function commit_endpoint() {
+    global $wpghs;
+    $url = $wpghs->api_base() . "/repos/";
+    $url = $url . $wpghs->repository() . "/git/commits";
+    return $url;
+  }
+
+  /**
+   * Api to get and create trees
+   */
+  function tree_endpoint() {
+    global $wpghs;
+    $url = $wpghs->api_base() . "/repos/";
+    $url = $url . $wpghs->repository() . "/git/trees";
+    return $url;
   }
 
   /**
@@ -108,7 +387,6 @@ class WordPress_GitHub_Sync_Controller {
     }
 
     $this->posts = $posts;
-    WordPress_GitHub_Sync::write_log( __( "Number of retrieved posts: ", WordPress_GitHub_Sync::$text_domain ) . count($this->posts) );
 
     $blobs = get_option( '_wpghs_exported_blobs' );
 
@@ -117,7 +395,6 @@ class WordPress_GitHub_Sync_Controller {
     }
 
     $this->blobs = $blobs;
-    WordPress_GitHub_Sync::write_log( __( "Number of retrived blobs: ", WordPress_GitHub_Sync::$text_domain ) . count($this->blobs) );
   }
 
   /**
@@ -126,7 +403,5 @@ class WordPress_GitHub_Sync_Controller {
   function save_data() {
     update_option( '_wpghs_posts_to_export', $this->posts );
     update_option( '_wpghs_exported_blobs', $this->blobs );
-    WordPress_GitHub_Sync::write_log( __( "Number of saved posts: ", WordPress_GitHub_Sync::$text_domain ) . count($this->posts) );
-    WordPress_GitHub_Sync::write_log( __( "Number of saved blobs: ", WordPress_GitHub_Sync::$text_domain ) . count($this->blobs) );
   }
 }

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -4,428 +4,457 @@
  */
 class WordPress_GitHub_Sync_Controller {
 
-  /**
-   * Instantiates a new Controller object
-   *
-   * $posts - array of post IDs to export
-   */
-  function __construct() {
-    $this->api = new WordPress_GitHub_Sync_Api;
-    $this->changed = false;
-    $this->posts = array();
-    $this->tree = array();
-  }
-
-  /**
-   * Reads the Webhook payload and syncs posts as necessary
-   */
-  function pull($payload) {
-    if ( strtolower($payload->repository->full_name) !== strtolower($this->api->repository()) ) {
-      WordPress_GitHub_Sync::write_log( strtolower($payload->repository->full_name) . __(" is an invalid repository.", WordPress_GitHub_Sync::$text_domain) );
-      return;
-    }
-
-    // the last term in the ref is the branch name
-    $refs = explode('/', $payload->ref);
-    $branch = array_pop( $refs );
-
-    if ( 'master' === $branch ) {
-      WordPress_GitHub_Sync::write_log( __("Not on the master branch.", WordPress_GitHub_Sync::$text_domain) );
-      return;
-    }
-
-    // We add wpghs to commits we push out, so we shouldn't pull them in again
-    if ( "wpghs" === substr( $payload->head_commit->message, -5 ) ) {
-      WordPress_GitHub_Sync::write_log( __("Already synced this commit.", WordPress_GitHub_Sync::$text_domain) );
-      return;
-    }
-
-    $commit = $this->api->get_commit($payload->head_commit->id);
-
-    if ( is_wp_error( $commit ) ) {
-      WordPress_GitHub_Sync::write_log( __("Failed getting commit with error: ", WordPress_GitHub_Sync::$text_domain) . $commit->get_error_message() );
-      return;
-    }
-
-    $this->import_tree($commit->tree->sha);
-
-    // Deleting posts from a payload is the only place
-    // we need to search posts by path; another way?
-    $removed = array();
-    foreach ($payload->commits as $commit) {
-      $removed  = array_merge( $removed,  $commit->removed  );
-    }
-    foreach (array_unique($removed) as $path) {
-      $post = new WordPress_GitHub_Sync_Post($path);
-      wp_delete_post($post->id);
-    }
-
-    WordPress_GitHub_Sync::write_log( __("Payload processed", WordPress_GitHub_Sync::$text_domain) );
-  }
-
-  /**
-   * Imports posts from the current master branch
-   */
-  function import_master() {
-    $commit = $this->api->last_commit();
-
-    if ( is_wp_error( $commit ) ) {
-      WordPress_GitHub_Sync::write_log( __("Failed getting last commit with error: ", WordPress_GitHub_Sync::$text_domain) . $commit->get_error_message() );
-      return;
-    }
-
-    if ( "wpghs" === substr( $commit->message, -5 ) ) {
-      WordPress_GitHub_Sync::write_log( __("Already synced this commit.", WordPress_GitHub_Sync::$text_domain) );
-      return;
-    }
-
-    $this->import_tree( $commit->tree->sha );
-  }
-
-  /**
-   * Imports posts from a given tree sha
-   */
-  function import_tree($sha) {
-    $tree = $this->api->get_tree_recursive($sha);
-
-    if ( is_wp_error( $tree ) ) {
-      WordPress_GitHub_Sync::write_log( __("Failed getting recursive tree with error: ", WordPress_GitHub_Sync::$text_domain) . $commit->get_error_message() );
-      return;
-    }
-
-    foreach ($tree as $blob) {
-      $this->import_blob( $blob );
-    }
-
-    WordPress_GitHub_Sync::write_log( __("Imported tree ", WordPress_GitHub_Sync::$text_domain) . $sha );
-  }
-
-  /**
-   * Imports a single blob content into matching post
-   */
-  function import_blob($blob) {
-    global $wpdb;
-
-    // Skip the repo's readme
-    if ( 'readme' === strtolower(substr($blob->path, 0, 6)) ) {
-      WordPress_GitHub_Sync::write_log( __("Skipping README", WordPress_GitHub_Sync::$text_domain) );
-      return;
-    }
-
-    // If the blob sha already matches a post, then move on
-    $id = $wpdb->get_var("SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_sha' AND meta_value = '$blob->sha'");
-    if ( $id ) {
-      WordPress_GitHub_Sync::write_log( __("Already synced blob ", WordPress_GitHub_Sync::$text_domain) . $blob->path );
-      return;
-    }
-
-    $blob = $this->api->get_blob($blob->sha);
-
-    if ( is_wp_error( $blob ) ) {
-      WordPress_GitHub_Sync::write_log( __("Failed getting blob with error: ", WordPress_GitHub_Sync::$text_domain) . $commit->get_error_message() );
-      return;
-    }
-
-    $content = base64_decode($blob->content);
-
-    // If it doesn't have YAML frontmatter, then move on
-    if ( '---' !== substr($content, 0, 3) ) {
-      WordPress_GitHub_Sync::write_log( __("No front matter on blob ", WordPress_GitHub_Sync::$text_domain) . $blob->sha );
-      return;
-    }
-
-    // Break out meta, if present
-    preg_match( "/(^---(.*?)---$)?(.*)/ms", $content, $matches );
-
-    $body = array_pop( $matches );
-
-    if (count($matches) == 3) {
-      $meta = spyc_load($matches[2]);
-      if ($meta['permalink']) $meta['permalink'] = str_replace(home_url(), '', get_permalink($meta['permalink']));
-    } else {
-      $meta = array();
-    }
-
-    if ( function_exists( 'wpmarkdown_markdown_to_html' ) ) {
-      $body = wpmarkdown_markdown_to_html( $body );
-    }
-
-    // Can we really just mash everything together here?
-    $args = array_merge( $meta, array(
-      "post_content" => $body,
-      "_sha"         => $blob->sha,
-    ) );
-
-    if ( !isset($args['ID']) ) {
-      wp_insert_post( $args );
-    } else {
-      wp_update_post( $args );
-    }
-  }
-
-  /**
-   * Export all the posts in the database to GitHub
-   */
-  function export_all() {
-    global $wpdb;
-
-    if ( $this->locked() ) {
-      return;
-    }
-
-    $posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ('post', 'page' )" );
-    $this->msg = "Full export from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ") - wpghs";
-
-    $this->get_tree();
-
-    WordPress_GitHub_Sync::write_log( __("Building the tree.", WordPress_GitHub_Sync::$text_domain ) );
-    foreach ($posts as $post_id) {
-      $post = new WordPress_GitHub_Sync_Post($post_id);
-      $this->post_to_tree($post);
-    }
-
-    $this->finalize();
-  }
-
-  /**
-   * Exports a single post to GitHub by ID
-   */
-  function export_post($post_id) {
-    if ( $this->locked() ) {
-      return;
-    }
-
-    $post = new WordPress_GitHub_Sync_Post($post_id);
-    $this->msg = "Syncing " . $post->github_path() . " from WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ") - wpghs";
-
-    $this->get_tree();
-
-    WordPress_GitHub_Sync::write_log( __("Building the tree.", WordPress_GitHub_Sync::$text_domain ) );
-    $this->post_to_tree($post);
-
-    $this->finalize();
-  }
-
-  /**
-   * Removes the post from the tree
-   */
-  function delete_post($post_id) {
-    if ( $this->locked() ) {
-      return;
-    }
-
-    $post = new WordPress_GitHub_Sync_Post($post_id);
-    $this->msg = "Deleting " . $post->github_path() . " via WordPress at " . site_url() . " (" . get_bloginfo( 'name' ) . ") - wpghs";
-
-    $this->get_tree();
-
-    WordPress_GitHub_Sync::write_log( __("Building the tree.", WordPress_GitHub_Sync::$text_domain ) );
-
-    $this->post_to_tree($post, true);
-
-    $this->finalize();
-  }
-
-  /**
-   * Takes the next post off the top of the list
-   * and exports it to the new GitHub tree
-   */
-  function post_to_tree($post, $remove = false) {
-    $match = false;
-
-    foreach ($this->tree as $index => $blob) {
-      if ( !isset($blob->sha)) {
-        continue;
-      }
-
-      if ( $blob->sha === $post->sha() ) {
-        unset($this->tree[ $index ]);
-        $match = true;
-
-        if ( ! $remove ) {
-          $this->tree[] = $this->new_blob($post, $blob);
-        } else {
-          $this->changed = true;
-        }
-
-        break;
-      }
-    }
-
-    if ( ! $match ) {
-      $this->tree[] = $this->new_blob($post);
-      $this->changed = true;
-    }
-  }
-
-  /**
-   * After all the blobs are saved,
-   * create the tree, commit, and adjust master ref
-   */
-  function finalize() {
-    if ( ! $this->changed ) {
-      $this->no_change();
-      return;
-    }
-
-    WordPress_GitHub_Sync::write_log(__( 'Creating the tree.', WordPress_GitHub_Sync::$text_domain ));
-    $tree = $this->api->create_tree(array_values($this->tree));
-
-    if ( is_wp_error( $tree ) ) {
-      $this->error($tree);
-      return;
-    }
-
-    WordPress_GitHub_Sync::write_log(__( 'Creating the commit.', WordPress_GitHub_Sync::$text_domain ));
-    $commit = $this->api->create_commit($tree->sha, $this->msg);
-
-    if ( is_wp_error( $commit ) ) {
-      $this->error($commit);
-      return;
-    }
-
-    WordPress_GitHub_Sync::write_log(__( 'Setting the master branch to our new commit.', WordPress_GitHub_Sync::$text_domain ));
-    $ref = $this->api->set_ref($commit->sha);
-
-    if ( is_wp_error( $ref ) ) {
-      $this->error($ref);
-      return;
-    }
-
-    $rtree = $this->api->last_tree_recursive();
-
-    WordPress_GitHub_Sync::write_log(__( 'Saving the shas.', WordPress_GitHub_Sync::$text_domain ));
-    $this->save_post_shas($rtree);
-
-    $this->success();
-  }
-
-  /**
-   * Combines a post and (potentially) a blob
-   *
-   * If no blob is provided, turns post into blob
-   *
-   * If blob is provided, compares blob to post
-   * and updates blob data based on differences
-   */
-  function new_blob($post, $blob = array()) {
-    if ( empty($blob) ) {
-      $blob = $this->blob_from_post($post);
-    } else {
-      unset($blob->url);
-      unset($blob->size);
-
-      if ( $blob->path !== $post->github_path()) {
-        $blob->path = $post->github_path();
-        $this->changed = true;
-      }
-
-      $blob_data = $this->api->get_blob($blob->sha);
-
-      if ( base64_decode($blob_data->content) !== $post->github_content() ) {
-        unset($blob->sha);
-        $blob->content = $post->github_content();
-        $this->changed = true;
-      }
-    }
-
-    return $blob;
-  }
-
-  /**
-   * Creates a blob with the data required for the tree
-   */
-  function blob_from_post($post) {
-    $blob = new stdClass;
-
-    $blob->path = $post->github_path();
-    $blob->mode = "100644";
-    $blob->type = "blob";
-    $blob->content = $post->github_content();
-
-    return $blob;
-  }
-
-  /**
-   * Use the new tree to save sha data
-   * for all the updated posts
-   */
-  function save_post_shas($tree) {
-    foreach ($this->posts as $post_id) {
-      $post = new WordPress_GitHub_Sync_Post($post_id);
-      $match = false;
-
-      foreach ($tree as $blob) {
-        // this might be a problem if the filename changed since it was set
-        // (i.e. post updated in middle mass export)
-        // solution?
-        if ($post->github_path() === $blob->path) {
-          $post->set_sha($blob->sha);
-          $match = true;
-          break;
-        }
-      }
-
-      if ( ! $match ) {
-        WordPress_GitHub_Sync::write_log( __('No sha matched for post ID ', WordPress_GitHub_Sync::$text_domain ) . $post_id);
-      }
-    }
-  }
-
-  /**
-   * Check if we're clear to call the api
-   */
-  function locked() {
-    global $wpghs;
-
-    if (! $this->api->oauth_token() || ! $this->api->repository() || $wpghs->push_lock) {
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Writes out the results of an unchanged export
-   */
-  function no_change() {
-    update_option( '_wpghs_export_complete', 'yes' );
-    WordPress_GitHub_Sync::write_log( __('There were no changes, so no additional commit was added.', WordPress_GitHub_Sync::$text_domain ), 'warning' );
-  }
-
-  /**
-   * Writes out the results of a successful export
-   */
-  function success() {
-    update_option( '_wpghs_export_complete', 'yes' );
-    update_option( '_wpghs_fully_exported', 'yes' );
-    WordPress_GitHub_Sync::write_log( __('Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain ), 'success' );
-  }
-
-  /**
-   * Writes out the results of an error and saves the data
-   */
-  function error($result) {
-    update_option( '_wpghs_export_error', $result->get_error_message() );
-    WordPress_GitHub_Sync::write_log( __("Error exporting to GitHub. Error: ", WordPress_GitHub_Sync::$text_domain ) . $result->get_error_message(), 'error' );
-  }
-
-  /**
-   * Retrieve the saved tree we're building
-   * or get the latest tree from the repo
-   */
-  function get_tree() {
-    if ( ! empty($this->tree) ) {
-      return;
-    }
-
-    $tree = $this->api->last_tree_recursive();
-
-    if ( is_wp_error( $tree ) ) {
-      WordPress_GitHub_Sync::write_log( __("Failed getting tree with error: ", WordPress_GitHub_Sync::$text_domain) . $tree->get_error_message() );
-      return;
-    }
-
-    $this->tree = $tree;
-  }
+	/**
+	 * Api object
+	 * @var WordPress_GitHub_Sync_Api
+	 */
+	public $api;
+
+	/**
+	 * Whether any posts have changed
+	 * @var boolean
+	 */
+	public $changed = false;
+
+	/**
+	 * Array of posts to export
+	 * @var array
+	 */
+	public $posts = array();
+
+	/**
+	 * Array representing new tre
+	 * @var array
+	 */
+	public $tree = array();
+
+	/**
+	 * Commit message
+	 * @var string
+	 */
+	public $msg = '';
+
+	/**
+	 * Instantiates a new Controller object
+	 *
+	 * $posts - array of post IDs to export
+	 */
+	public 	function __construct() {
+		$this->api = new WordPress_GitHub_Sync_Api;
+	}
+
+	/**
+	 * Reads the Webhook payload and syncs posts as necessary
+	 */
+	public function pull($payload) {
+		if ( strtolower( $payload->repository->full_name ) !== strtolower( $this->api->repository() ) ) {
+			WordPress_GitHub_Sync::write_log( strtolower( $payload->repository->full_name ) . __( ' is an invalid repository.', WordPress_GitHub_Sync::$text_domain ) );
+			return;
+		}
+
+		// the last term in the ref is the branch name
+		$refs = explode( '/', $payload->ref );
+		$branch = array_pop( $refs );
+
+		if ( 'master' === $branch ) {
+			WordPress_GitHub_Sync::write_log( __( 'Not on the master branch.', WordPress_GitHub_Sync::$text_domain ) );
+			return;
+		}
+
+		// We add wpghs to commits we push out, so we shouldn't pull them in again
+		if ( 'wpghs' === substr( $payload->head_commit->message, -5 ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Already synced this commit.', WordPress_GitHub_Sync::$text_domain ) );
+			return;
+		}
+
+		$commit = $this->api->get_commit( $payload->head_commit->id );
+
+		if ( is_wp_error( $commit ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Failed getting commit with error: ', WordPress_GitHub_Sync::$text_domain ) . $commit->get_error_message() );
+			return;
+		}
+
+		$this->import_tree( $commit->tree->sha );
+
+		// Deleting posts from a payload is the only place
+		// we need to search posts by path; another way?
+		$removed = array();
+		foreach ( $payload->commits as $commit ) {
+			$removed  = array_merge( $removed,  $commit->removed );
+		}
+		foreach ( array_unique( $removed ) as $path ) {
+			$post = new WordPress_GitHub_Sync_Post( $path );
+			wp_delete_post( $post->id );
+		}
+
+		WordPress_GitHub_Sync::write_log( __( 'Payload processed', WordPress_GitHub_Sync::$text_domain ) );
+	}
+
+	/**
+	 * Imports posts from the current master branch
+	 */
+	public function import_master() {
+		$commit = $this->api->last_commit();
+
+		if ( is_wp_error( $commit ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Failed getting last commit with error: ', WordPress_GitHub_Sync::$text_domain ) . $commit->get_error_message() );
+			return;
+		}
+
+		if ( 'wpghs' === substr( $commit->message, -5 ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Already synced this commit.', WordPress_GitHub_Sync::$text_domain ) );
+			return;
+		}
+
+		$this->import_tree( $commit->tree->sha );
+	}
+
+	/**
+	 * Imports posts from a given tree sha
+	 */
+	public function import_tree($sha) {
+		$tree = $this->api->get_tree_recursive( $sha );
+
+		if ( is_wp_error( $tree ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Failed getting recursive tree with error: ', WordPress_GitHub_Sync::$text_domain ) . $tree->get_error_message() );
+			return;
+		}
+
+		foreach ( $tree as $blob ) {
+			$this->import_blob( $blob );
+		}
+
+		WordPress_GitHub_Sync::write_log( __( 'Imported tree ', WordPress_GitHub_Sync::$text_domain ) . $sha );
+	}
+
+	/**
+	 * Imports a single blob content into matching post
+	 */
+	public function import_blob($blob) {
+		global $wpdb;
+
+		// Skip the repo's readme
+		if ( 'readme' === strtolower( substr( $blob->path, 0, 6 ) ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Skipping README', WordPress_GitHub_Sync::$text_domain ) );
+			return;
+		}
+
+		// If the blob sha already matches a post, then move on
+		$id = $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_sha' AND meta_value = '$blob->sha'" );
+		if ( $id ) {
+			WordPress_GitHub_Sync::write_log( __( 'Already synced blob ', WordPress_GitHub_Sync::$text_domain ) . $blob->path );
+			return;
+		}
+
+		$blob = $this->api->get_blob( $blob->sha );
+
+		if ( is_wp_error( $blob ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Failed getting blob with error: ', WordPress_GitHub_Sync::$text_domain ) . $blob->get_error_message() );
+			return;
+		}
+
+		$content = base64_decode( $blob->content );
+
+		// If it doesn't have YAML frontmatter, then move on
+		if ( '---' !== substr( $content, 0, 3 ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'No front matter on blob ', WordPress_GitHub_Sync::$text_domain ) . $blob->sha );
+			return;
+		}
+
+		// Break out meta, if present
+		preg_match( '/(^---(.*?)---$)?(.*)/ms', $content, $matches );
+
+		$body = array_pop( $matches );
+
+		if ( 3 === count( $matches ) ) {
+			$meta = spyc_load( $matches[2] );
+			if ( $meta['permalink'] ) {
+				$meta['permalink'] = str_replace( home_url(), '', get_permalink( $meta['permalink'] ) );
+			}
+		} else {
+			$meta = array();
+		}
+
+		if ( function_exists( 'wpmarkdown_markdown_to_html' ) ) {
+			$body = wpmarkdown_markdown_to_html( $body );
+		}
+
+		// Can we really just mash everything together here?
+		$args = array_merge( $meta, array(
+			'post_content' => $body,
+			'_sha'         => $blob->sha,
+		) );
+
+		if ( ! isset($args['ID']) ) {
+			wp_insert_post( $args );
+		} else {
+			wp_update_post( $args );
+		}
+	}
+
+	/**
+	 * Export all the posts in the database to GitHub
+	 */
+	public function export_all() {
+		global $wpdb;
+
+		if ( $this->locked() ) {
+			return;
+		}
+
+		$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ('post', 'page' )" );
+		$this->msg = 'Full export from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+
+		$this->get_tree();
+
+		WordPress_GitHub_Sync::write_log( __( 'Building the tree.', WordPress_GitHub_Sync::$text_domain ) );
+		foreach ( $posts as $post_id ) {
+			$post = new WordPress_GitHub_Sync_Post( $post_id );
+			$this->post_to_tree( $post );
+		}
+
+		$this->finalize();
+	}
+
+	/**
+	 * Exports a single post to GitHub by ID
+	 */
+	public function export_post($post_id) {
+		if ( $this->locked() ) {
+			return;
+		}
+
+		$post = new WordPress_GitHub_Sync_Post( $post_id );
+		$this->msg = 'Syncing ' . $post->github_path() . ' from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+
+		$this->get_tree();
+
+		WordPress_GitHub_Sync::write_log( __( 'Building the tree.', WordPress_GitHub_Sync::$text_domain ) );
+		$this->post_to_tree( $post );
+
+		$this->finalize();
+	}
+
+	/**
+	 * Removes the post from the tree
+	 */
+	public function delete_post($post_id) {
+		if ( $this->locked() ) {
+			return;
+		}
+
+		$post = new WordPress_GitHub_Sync_Post( $post_id );
+		$this->msg = 'Deleting ' . $post->github_path() . ' via WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+
+		$this->get_tree();
+
+		WordPress_GitHub_Sync::write_log( __( 'Building the tree.', WordPress_GitHub_Sync::$text_domain ) );
+
+		$this->post_to_tree( $post, true );
+
+		$this->finalize();
+	}
+
+	/**
+	 * Takes the next post off the top of the list
+	 * and exports it to the new GitHub tree
+	 */
+	public function post_to_tree($post, $remove = false) {
+		$match = false;
+
+		foreach ( $this->tree as $index => $blob ) {
+			if ( ! isset( $blob->sha ) ) {
+				continue;
+			}
+
+			if ( $blob->sha === $post->sha() ) {
+				unset($this->tree[ $index ]);
+				$match = true;
+
+				if ( ! $remove ) {
+					$this->tree[] = $this->new_blob( $post, $blob );
+				} else {
+					$this->changed = true;
+				}
+
+				break;
+			}
+		}
+
+		if ( ! $match ) {
+			$this->tree[] = $this->new_blob( $post );
+			$this->changed = true;
+		}
+	}
+
+	/**
+	 * After all the blobs are saved,
+	 * create the tree, commit, and adjust master ref
+	 */
+	public function finalize() {
+		if ( ! $this->changed ) {
+			$this->no_change();
+			return;
+		}
+
+		WordPress_GitHub_Sync::write_log( __( 'Creating the tree.', WordPress_GitHub_Sync::$text_domain ) );
+		$tree = $this->api->create_tree( array_values( $this->tree ) );
+
+		if ( is_wp_error( $tree ) ) {
+			$this->error( $tree );
+			return;
+		}
+
+		WordPress_GitHub_Sync::write_log( __( 'Creating the commit.', WordPress_GitHub_Sync::$text_domain ) );
+		$commit = $this->api->create_commit( $tree->sha, $this->msg );
+
+		if ( is_wp_error( $commit ) ) {
+			$this->error( $commit );
+			return;
+		}
+
+		WordPress_GitHub_Sync::write_log( __( 'Setting the master branch to our new commit.', WordPress_GitHub_Sync::$text_domain ) );
+		$ref = $this->api->set_ref( $commit->sha );
+
+		if ( is_wp_error( $ref ) ) {
+			$this->error( $ref );
+			return;
+		}
+
+		$rtree = $this->api->last_tree_recursive();
+
+		WordPress_GitHub_Sync::write_log( __( 'Saving the shas.', WordPress_GitHub_Sync::$text_domain ) );
+		$this->save_post_shas( $rtree );
+
+		$this->success();
+	}
+
+	/**
+	 * Combines a post and (potentially) a blob
+	 *
+	 * If no blob is provided, turns post into blob
+	 *
+	 * If blob is provided, compares blob to post
+	 * and updates blob data based on differences
+	 */
+	public function new_blob($post, $blob = array()) {
+		if ( empty($blob) ) {
+			$blob = $this->blob_from_post( $post );
+		} else {
+			unset($blob->url);
+			unset($blob->size);
+
+			if ( $blob->path !== $post->github_path() ) {
+				$blob->path = $post->github_path();
+				$this->changed = true;
+			}
+
+			$blob_data = $this->api->get_blob( $blob->sha );
+
+			if ( base64_decode( $blob_data->content ) !== $post->github_content() ) {
+				unset($blob->sha);
+				$blob->content = $post->github_content();
+				$this->changed = true;
+			}
+		}
+
+		return $blob;
+	}
+
+	/**
+	 * Creates a blob with the data required for the tree
+	 */
+	public function blob_from_post($post) {
+		$blob = new stdClass;
+
+		$blob->path = $post->github_path();
+		$blob->mode = '100644';
+		$blob->type = 'blob';
+		$blob->content = $post->github_content();
+
+		return $blob;
+	}
+
+	/**
+	 * Use the new tree to save sha data
+	 * for all the updated posts
+	 */
+	public function save_post_shas($tree) {
+		foreach ( $this->posts as $post_id ) {
+			$post = new WordPress_GitHub_Sync_Post( $post_id );
+			$match = false;
+
+			foreach ( $tree as $blob ) {
+				// this might be a problem if the filename changed since it was set
+				// (i.e. post updated in middle mass export)
+				// solution?
+				if ( $post->github_path() === $blob->path ) {
+					$post->set_sha( $blob->sha );
+					$match = true;
+					break;
+				}
+			}
+
+			if ( ! $match ) {
+				WordPress_GitHub_Sync::write_log( __( 'No sha matched for post ID ', WordPress_GitHub_Sync::$text_domain ) . $post_id );
+			}
+		}
+	}
+
+	/**
+	 * Check if we're clear to call the api
+	 */
+	public function locked() {
+		global $wpghs;
+
+		if ( ! $this->api->oauth_token() || ! $this->api->repository() || $wpghs->push_lock ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Writes out the results of an unchanged export
+	 */
+	public function no_change() {
+		update_option( '_wpghs_export_complete', 'yes' );
+		WordPress_GitHub_Sync::write_log( __( 'There were no changes, so no additional commit was added.', WordPress_GitHub_Sync::$text_domain ), 'warning' );
+	}
+
+	/**
+	 * Writes out the results of a successful export
+	 */
+	public function success() {
+		update_option( '_wpghs_export_complete', 'yes' );
+		update_option( '_wpghs_fully_exported', 'yes' );
+		WordPress_GitHub_Sync::write_log( __( 'Export to GitHub completed successfully.', WordPress_GitHub_Sync::$text_domain ), 'success' );
+	}
+
+	/**
+	 * Writes out the results of an error and saves the data
+	 */
+	public function error($result) {
+		update_option( '_wpghs_export_error', $result->get_error_message() );
+		WordPress_GitHub_Sync::write_log( __( 'Error exporting to GitHub. Error: ', WordPress_GitHub_Sync::$text_domain ) . $result->get_error_message(), 'error' );
+	}
+
+	/**
+	 * Retrieve the saved tree we're building
+	 * or get the latest tree from the repo
+	 */
+	public function get_tree() {
+		if ( ! empty($this->tree) ) {
+			return;
+		}
+
+		$tree = $this->api->last_tree_recursive();
+
+		if ( is_wp_error( $tree ) ) {
+			WordPress_GitHub_Sync::write_log( __( 'Failed getting tree with error: ', WordPress_GitHub_Sync::$text_domain ) . $tree->get_error_message() );
+			return;
+		}
+
+		$this->tree = $tree;
+	}
 }

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -276,11 +276,6 @@ class WordPress_GitHub_Sync_Controller {
       return;
     }
 
-    $rtree = $this->api->last_tree_recursive();
-
-    WordPress_GitHub_Sync::write_log(__( 'Saving the shas.', WordPress_GitHub_Sync::$text_domain ));
-    $this->save_post_shas($rtree);
-
     WordPress_GitHub_Sync::write_log(__( 'Creating the commit.', WordPress_GitHub_Sync::$text_domain ));
     $commit = $this->api->create_commit($tree->sha, $this->msg);
 
@@ -296,6 +291,11 @@ class WordPress_GitHub_Sync_Controller {
       $this->error($ref);
       return;
     }
+
+    $rtree = $this->api->last_tree_recursive();
+
+    WordPress_GitHub_Sync::write_log(__( 'Saving the shas.', WordPress_GitHub_Sync::$text_domain ));
+    $this->save_post_shas($rtree);
 
     $this->success();
   }

--- a/lib/post.php
+++ b/lib/post.php
@@ -188,7 +188,7 @@ class WordPress_GitHub_Sync_Post {
     if ( ! $sha && 'yes' === get_option( '_wpghs_fully_exported' ) ) {
       $data = $this->api->remote_contents($this);
 
-      if ($data && isset($data->sha)) {
+      if ( ! is_wp_error( $data ) ) {
         add_post_meta( $this->id, '_sha', $data->sha, true ) || update_post_meta( $this->id, '_sha', $data->sha );
         $sha = $data->sha;
       }

--- a/lib/post.php
+++ b/lib/post.php
@@ -217,6 +217,7 @@ class WordPress_GitHub_Sync_Post {
   function meta() {
 
     $meta = array(
+      'ID'           => $this->post->ID,
       'post_title'   => get_the_title( $this->post ),
       'author'       => get_userdata( $this->post->post_author )->display_name,
       'post_date'    => $this->post->post_date,

--- a/lib/post.php
+++ b/lib/post.php
@@ -3,240 +3,266 @@
  * The post object which represents both the GitHub and WordPress post
  */
 class WordPress_GitHub_Sync_Post {
-  public $id = 0;
 
-  /**
-   * Instantiates a new Post object
-   *
-   * $id_or_path - (int|string) either a postID (WordPress) or a path to a file (GitHub)
-   *
-   * Returns the Post object, duh
-   */
-  function __construct( $id_or_path ) {
+	/**
+	 * Api object
+	 * @var WordPress_GitHub_Sync_Api
+	 */
+	public $api;
 
-    $this->api = new WordPress_GitHub_Sync_Api;
+	/**
+	 * Post ID
+	 * @var integer
+	 */
+	public $id = 0;
 
-    if (is_numeric($id_or_path)) {
-      $this->id = $id_or_path;
-    } else {
-      $this->path = $id_or_path;
-      $this->id = $this->id_from_path();
-    }
+	/**
+	 * Path to the file
+	 * @var string
+	 */
+	public $path;
 
-    $this->post = get_post($this->id);
-  }
+	/**
+	 * Post object
+	 * @var WP_Post
+	 */
+	public $post;
 
-  /**
-   * Parse the various parts of a filename from a path
-   *
-   * @todo - PAGE SUPPORT
-   */
-  function parts_from_path() {
-    preg_match("/_posts\/([0-9]{4})-([0-9]{2})-([0-9]{2})-(.*)\.md/", $this->path, $matches);
-    return $matches;
-  }
+	/**
+	 * Instantiates a new Post object
+	 *
+	 * $id_or_path - (int|string) either a postID (WordPress) or a path to a file (GitHub)
+	 *
+	 * Returns the Post object, duh
+	 */
+	public function __construct( $id_or_path ) {
 
-  /**
-   * Extract's the post's title from its path
-   */
-  function title_from_path() {
-    $matches = $this->parts_from_path();
-    return $matches[4];
-  }
+		$this->api = new WordPress_GitHub_Sync_Api;
 
-  /**
-   * Extract's the post's date from its path
-   */
-  function date_from_path() {
-    $matches = $this->parts_from_path();
-    return $matches[1] . "-" . $matches[2] . "-" . $matches[3] . "00:00:00";
-  }
+		if ( is_numeric( $id_or_path ) ) {
+			$this->id = $id_or_path;
+		} else {
+			$this->path = $id_or_path;
+			$this->id = $this->id_from_path();
+		}
 
-  /**
-   * Determines the post's WordPress ID from its GitHub path
-   * Creates the WordPress post if it does not exist
-   */
-  function id_from_path() {
-    global $wpdb;
+		$this->post = get_post( $this->id );
+	}
 
-    $id = $wpdb->get_var("SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_wpghs_github_path' AND meta_value = '$this->path'");
+	/**
+	 * Parse the various parts of a filename from a path
+	 *
+	 * @todo - PAGE SUPPORT
+	 */
+	public function parts_from_path() {
+		preg_match( '/_posts\/([0-9]{4})-([0-9]{2})-([0-9]{2})-(.*)\.md/', $this->path, $matches );
+		return $matches;
+	}
 
-    if (!$id) {
-      $title = $this->title_from_path();
-      $id = $wpdb->get_var("SELECT ID FROM $wpdb->posts WHERE post_name = '$title'");
-    }
+	/**
+	 * Extract's the post's title from its path
+	 */
+	public function title_from_path() {
+		$matches = $this->parts_from_path();
+		return $matches[4];
+	}
 
-    if (!$id) {
-      $id = wp_insert_post( array(
-          'post_name' => $this->title_from_path(),
-          'post_date' => $this->date_from_path()
-        )
-      );
-    }
+	/**
+	 * Extract's the post's date from its path
+	 */
+	public function date_from_path() {
+		$matches = $this->parts_from_path();
+		return $matches[1] . '-' . $matches[2] . '-' . $matches[3] . '00:00:00';
+	}
 
-    return $id;
-  }
+	/**
+	 * Determines the post's WordPress ID from its GitHub path
+	 * Creates the WordPress post if it does not exist
+	 */
+	public function id_from_path() {
+		global $wpdb;
 
-  /**
-   * Returns the post type
-   */
-  function type() {
-    return $this->post->post_type;
-  }
+		$id = $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_wpghs_github_path' AND meta_value = '$this->path'" );
 
-  /**
-   * Returns the post name
-   */
-  function name() {
-    return $this->post->post_name;
-  }
+		if ( ! $id ) {
+			$title = $this->title_from_path();
+			$id = $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE post_name = '$title'" );
+		}
 
-  /**
-   * Combines the 2 content parts for GitHub
-   */
-  function github_content() {
-    return $this->front_matter() . $this->post_content();
-  }
+		if ( ! $id ) {
+			$id = wp_insert_post( array(
+					'post_name' => $this->title_from_path(),
+					'post_date' => $this->date_from_path()
+				)
+			);
+		}
 
-  /**
-   * The post's YAML frontmatter
-   *
-   * Returns String the YAML frontmatter, ready to be written to the file
-   */
-  function front_matter() {
-    return Spyc::YAMLDump($this->meta(), false, false, true) . "---\n";
-  }
+		return $id;
+	}
 
-  /**
-   * Returns the post_content
-   *
-   * Markdownify's the content if applicable
-   */
-  function post_content() {
-    $content = $this->post->post_content;
+	/**
+	 * Returns the post type
+	 */
+	public function type() {
+		return $this->post->post_type;
+	}
 
-    if ( function_exists( 'wpmarkdown_html_to_markdown' ) ) {
-      $content = wpmarkdown_html_to_markdown( $content );
-    }
+	/**
+	 * Returns the post name
+	 */
+	public function name() {
+		return $this->post->post_name;
+	}
 
-    return apply_filters( 'wpghs_content', $content );
-  }
+	/**
+	 * Combines the 2 content parts for GitHub
+	 */
+	public function github_content() {
+		return $this->front_matter() . $this->post_content();
+	}
 
-  /**
-   * Retrieves or calculates the proper GitHub path for a given post
-   *
-   * Returns (string) the path relative to repo root
-   */
-  function github_path() {
-    return $this->github_folder() . $this->github_filename();
-  }
+	/**
+	 * The post's YAML frontmatter
+	 *
+	 * Returns String the YAML frontmatter, ready to be written to the file
+	 */
+	public function front_matter() {
+		return Spyc::YAMLDump( $this->meta(), false, false, true ) . "---\n";
+	}
 
-  /**
-   * Get GitHub folder based on post
-   */
-  function github_folder() {
-    $folder = "";
+	/**
+	 * Returns the post_content
+	 *
+	 * Markdownify's the content if applicable
+	 */
+	public function post_content() {
+		$content = $this->post->post_content;
 
-    if ($this->type() == "post") {
-      $folder = "_posts/";
-    }
+		if ( function_exists( 'wpmarkdown_html_to_markdown' ) ) {
+			$content = wpmarkdown_html_to_markdown( $content );
+		}
 
-    return $folder;
-  }
+		return apply_filters( 'wpghs_content', $content );
+	}
 
-  /**
-   * Build GitHub filename based on post
-   */
-  function github_filename() {
-    $filename = "";
+	/**
+	 * Retrieves or calculates the proper GitHub path for a given post
+	 *
+	 * Returns (string) the path relative to repo root
+	 */
+	public function github_path() {
+		return $this->github_folder() . $this->github_filename();
+	}
 
-    if ($this->type() == "post") {
-      $filename = get_the_time("Y-m-d-", $this->id) . $this->name() . ".md";
-    } elseif ($this->type() == "page") {
-      $filename = get_page_uri( $this->id ) . ".md";
-    }
+	/**
+	 * Get GitHub folder based on post
+	 */
+	public function github_folder() {
+		$folder = '';
 
-    return $filename;
-  }
+		if ( 'post' === $this->type() ) {
+			$folder = '_posts/';
+		}
 
-  /**
-   * Determines the last author to modify the post
-   *
-   * Returns Array an array containing the author name and email
-   */
-  function last_modified_author() {
-    if ( $last_id = get_post_meta( $this->id, '_edit_last', true) ) {
-      $user = get_userdata($last_id);
-      if (!$user) return array();
-      return array( "name" => $user->display_name, "email" => $user->user_email );
-    } else {
-      return array();
-    }
-  }
+		return $folder;
+	}
 
-  /**
-   * The post's sha
-   * Cached as post meta, or will make a live call if need be
-   *
-   * Returns String the sha1 hash
-   */
-  function sha() {
-    $sha = get_post_meta( $this->id, "_sha", true);
+	/**
+	 * Build GitHub filename based on post
+	 */
+	public function github_filename() {
+		$filename = '';
 
-    // If we've done a full export and we have no sha
-    // then we should try a live check to see if it exists
-    if ( ! $sha && 'yes' === get_option( '_wpghs_fully_exported' ) ) {
-      $data = $this->api->remote_contents($this);
+		if ( 'post' === $this->type() ) {
+			$filename = get_the_time( 'Y-m-d-', $this->id ) . $this->name() . '.md';
+		} elseif ( 'page' === $this->type() ) {
+			$filename = get_page_uri( $this->id ) . '.md';
+		}
 
-      if ( ! is_wp_error( $data ) ) {
-        add_post_meta( $this->id, '_sha', $data->sha, true ) || update_post_meta( $this->id, '_sha', $data->sha );
-        $sha = $data->sha;
-      }
-    }
+		return $filename;
+	}
 
-    // if the sha still doesn't exist, then it's empty
-    if ( ! $sha ) {
-      $sha = "";
-    }
+	/**
+	 * Determines the last author to modify the post
+	 *
+	 * Returns Array an array containing the author name and email
+	 */
+	public function last_modified_author() {
+		if ( $last_id = get_post_meta( $this->id, '_edit_last', true ) ) {
+			$user = get_userdata( $last_id );
+			if ( ! $user ) {
+				return array();
+			}
+			return array( 'name' => $user->display_name, 'email' => $user->user_email );
+		} else {
+			return array();
+		}
+	}
 
-    return $sha;
-  }
+	/**
+	 * The post's sha
+	 * Cached as post meta, or will make a live call if need be
+	 *
+	 * Returns String the sha1 hash
+	 */
+	public function sha() {
+		$sha = get_post_meta( $this->id, '_sha', true );
 
-  /**
-   * Save the sha to post
-   */
-  function set_sha($sha) {
-    add_post_meta( $this->id, '_sha', $sha, true ) || update_post_meta( $this->id, '_sha', $sha );
-  }
+		// If we've done a full export and we have no sha
+		// then we should try a live check to see if it exists
+		if ( ! $sha && 'yes' === get_option( '_wpghs_fully_exported' ) ) {
+			$data = $this->api->remote_contents( $this );
 
-  /**
-   * The post's metadata
-   *
-   * Returns Array the post's metadata
-   */
-  function meta() {
+			if ( ! is_wp_error( $data ) ) {
+				add_post_meta( $this->id, '_sha', $data->sha, true ) || update_post_meta( $this->id, '_sha', $data->sha );
+				$sha = $data->sha;
+			}
+		}
 
-    $meta = array(
-      'ID'           => $this->post->ID,
-      'post_title'   => get_the_title( $this->post ),
-      'author'       => get_userdata( $this->post->post_author )->display_name,
-      'post_date'    => $this->post->post_date,
-      'post_excerpt' => $this->post->post_excerpt,
-      'layout'       => get_post_type( $this->post ),
-      'permalink'    => get_permalink( $this->post )
-    );
+		// if the sha still doesn't exist, then it's empty
+		if ( ! $sha ) {
+			$sha = '';
+		}
 
-    //convert traditional post_meta values, hide hidden values
-    foreach ( get_post_custom( $this->id ) as $key => $value ) {
+		return $sha;
+	}
 
-      if ( substr( $key, 0, 1 ) == '_' )
-        continue;
+	/**
+	 * Save the sha to post
+	 */
+	public function set_sha($sha) {
+		add_post_meta( $this->id, '_sha', $sha, true ) || update_post_meta( $this->id, '_sha', $sha );
+	}
 
-      $meta[ $key ] = $value;
+	/**
+	 * The post's metadata
+	 *
+	 * Returns Array the post's metadata
+	 */
+	public function meta() {
 
-    }
+		$meta = array(
+			'ID'           => $this->post->ID,
+			'post_title'   => get_the_title( $this->post ),
+			'author'       => get_userdata( $this->post->post_author )->display_name,
+			'post_date'    => $this->post->post_date,
+			'post_excerpt' => $this->post->post_excerpt,
+			'layout'       => get_post_type( $this->post ),
+			'permalink'    => get_permalink( $this->post )
+		);
 
-    return $meta;
+		//convert traditional post_meta values, hide hidden values
+		foreach ( get_post_custom( $this->id ) as $key => $value ) {
 
-  }
+			if ( '_' === substr( $key, 0, 1 ) ) {
+				continue;
+			}
+
+			$meta[ $key ] = $value;
+
+		}
+
+		return $meta;
+
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,9 @@
 <?php
 
-$_tests_dir = getenv('WP_TESTS_DIR');
-if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
 
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,3 +12,5 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
 
+require dirname( __FILE__ ) . '/../vendor/jdgrimes/wp-http-testcase/wp-http-testcase.php';
+WP_HTTP_TestCase::init();

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1,0 +1,143 @@
+<?php
+
+class WordPress_GitHub_Sync_Api_Test extends WP_HTTP_TestCase {
+
+	function setUp() {
+		parent::setUp();
+		WP_HTTP_TestCase::init();
+		update_option( "wpghs_repository", "person/repo" );
+		update_option( "wpghs_oauth_token", "the-token" );
+		update_option( "wpghs_host", "github.api" );
+		$this->http_responder = array( $this, 'mock_github_api' );
+		$this->api = new WordPress_GitHub_Sync_Api;
+	}
+
+	function test_should_return_blob() {
+		$response = $this->api->get_blob('123');
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertEquals( "Content of the blob", $response->content);
+		$this->assertEquals( "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15", $response->sha);
+	}
+
+	function test_should_return_tree() {
+		$response = $this->api->get_tree_recursive('123');
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertCount(2, $response);
+	}
+
+	function test_should_return_commit() {
+		$response = $this->api->get_commit('123');
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertEquals( "added readme, because im a good github citizen\n", $response->message);
+		$this->assertEquals( "7638417db6d59f3c431d3e1f261cc637155684cd", $response->sha);
+	}
+
+	function test_should_return_master_reference() {
+		$response = $this->api->get_ref_master();
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertEquals( "aa218f56b14c9653891f9e74264a383fa43fefbd", $response->object->sha);
+	}
+
+	function test_should_create_tree() {
+		$response = $this->api->create_tree(array());
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertEquals('cd8274d15fa3ae2ab983129fb037999f264ba9a7', $response->sha);
+	}
+
+	function test_should_create_commit() {
+		$response = $this->api->create_commit('1234', 'New Commit');
+
+		$this->assertCount(2, $this->http_requests);
+		$this->assertEquals('7638417db6d59f3c431d3e1f261cc637155684cd', $response->sha);
+	}
+
+	function test_should_update_master_reference() {
+		$response = $this->api->set_ref('123');
+
+		$this->assertCount(1, $this->http_requests);
+		$this->assertEquals( "aa218f56b14c9653891f9e74264a383fa43fefbd", $response->object->sha);
+	}
+
+	function test_should_return_lastest_tree() {
+		$response = $this->api->last_tree_recursive();
+
+		$this->assertCount(3, $this->http_requests);
+		$this->assertCount(2, $response);
+	}
+
+	/**
+	 * This does some checks and fails the test if something is wrong
+	 * or returns intended mock data for the given endpoint + method
+	 */
+	function mock_github_api( $request, $url ) {
+		if ( substr( $url, 0, 10) !== "github.api" ) {
+			$this->assertTrue( false, "Didn't call the correct host" );
+		}
+
+		$url = explode( '/',  substr( $url, 11 ) );
+
+		if ( $url[0] !== "repos" ) {
+			$this->assertTrue( false, "Didn't call the repos endpoint" );
+		}
+
+		if ( $url[1] !== "person" || $url[2] !== "repo"  ) {
+			$this->assertTrue( false, "Didn't call the correct repo" );
+		}
+
+		if ( "GET" === $request['method'] ) {
+			return $this->mock_get_requests($url[3], $url[4]);
+		}
+
+		if ( "POST" === $request['method'] ) {
+			return $this->mock_post_requests($url[3], $url[4], $request['body']);
+		}
+	}
+
+	function mock_get_requests( $api, $endpoint ) {
+		$get = array(
+			"git/blobs" => array("body" => '{"content": "Content of the blob","encoding": "utf-8","url": "https://api.github.com/repos/octocat/example/git/blobs/3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","sha": "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","size": 100}'),
+			"git/trees" => array("body" => '{"sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 526,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir","mode": "040000","type": "tree","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir/README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 2227357,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"}],"truncated": false}'),
+			"git/commits" => array("body" => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}'),
+			"git/refs" => array("body" => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}'),
+		);
+
+		$response = $get[ $api . "/" . $endpoint ];
+		$response['headers'] = array( "status" => "200 OK" );
+
+		return $response;
+	}
+
+	function mock_post_requests( $api, $endpoint, $body ) {
+		$post = array(
+			"git/trees" => array('body'=> '{"sha": "cd8274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/octocat/Hello-World/trees/cd8274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "file.rb","mode": "100644","type": "blob","size": 132,"sha": "7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b","url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b"}]}'),
+			"git/commits" => array("body" => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}'),
+			"git/refs" => array("body" => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}'),
+		);
+
+		if ( "trees" === $endpoint ) {
+			$this->assertObjectHasAttribute( 'tree', json_decode($body) );
+		}
+
+		if ( "commits" === $endpoint ) {
+			$this->assertObjectHasAttribute( 'message', json_decode($body) );
+			$this->assertObjectHasAttribute( 'author', json_decode($body) );
+			$this->assertObjectHasAttribute( 'tree', json_decode($body) );
+			$this->assertObjectHasAttribute( 'parents', json_decode($body) );
+		}
+
+		if ( "refs" === $endpoint ) {
+			$this->assertObjectHasAttribute( 'sha', json_decode($body) );
+		}
+
+		$response = $post[ $api . "/" . $endpoint ];
+		$response['headers'] = array( "status" => "201 CREATED" );
+
+		return $response;
+	}
+}
+

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -2,140 +2,140 @@
 
 class WordPress_GitHub_Sync_Api_Test extends WP_HTTP_TestCase {
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 		WP_HTTP_TestCase::init();
-		update_option( "wpghs_repository", "person/repo" );
-		update_option( "wpghs_oauth_token", "the-token" );
-		update_option( "wpghs_host", "github.api" );
+		update_option( 'wpghs_repository', 'person/repo' );
+		update_option( 'wpghs_oauth_token', 'the-token' );
+		update_option( 'wpghs_host', 'github.api' );
 		$this->http_responder = array( $this, 'mock_github_api' );
 		$this->api = new WordPress_GitHub_Sync_Api;
 	}
 
-	function test_should_return_blob() {
-		$response = $this->api->get_blob('123');
+	public function test_should_return_blob() {
+		$response = $this->api->get_blob( '123' );
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertEquals( "Content of the blob", $response->content);
-		$this->assertEquals( "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15", $response->sha);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertEquals( 'Content of the blob', $response->content );
+		$this->assertEquals( '3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15', $response->sha );
 	}
 
-	function test_should_return_tree() {
-		$response = $this->api->get_tree_recursive('123');
+	public function test_should_return_tree() {
+		$response = $this->api->get_tree_recursive( '123' );
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertCount(2, $response);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertCount( 2, $response );
 	}
 
-	function test_should_return_commit() {
-		$response = $this->api->get_commit('123');
+	public function test_should_return_commit() {
+		$response = $this->api->get_commit( '123' );
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertEquals( "added readme, because im a good github citizen\n", $response->message);
-		$this->assertEquals( "7638417db6d59f3c431d3e1f261cc637155684cd", $response->sha);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertEquals( "added readme, because im a good github citizen\n", $response->message );
+		$this->assertEquals( '7638417db6d59f3c431d3e1f261cc637155684cd', $response->sha );
 	}
 
-	function test_should_return_master_reference() {
+	public function test_should_return_master_reference() {
 		$response = $this->api->get_ref_master();
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertEquals( "aa218f56b14c9653891f9e74264a383fa43fefbd", $response->object->sha);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertEquals( 'aa218f56b14c9653891f9e74264a383fa43fefbd', $response->object->sha );
 	}
 
-	function test_should_create_tree() {
-		$response = $this->api->create_tree(array());
+	public function test_should_create_tree() {
+		$response = $this->api->create_tree( array() );
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertEquals('cd8274d15fa3ae2ab983129fb037999f264ba9a7', $response->sha);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertEquals( 'cd8274d15fa3ae2ab983129fb037999f264ba9a7', $response->sha );
 	}
 
-	function test_should_create_commit() {
-		$response = $this->api->create_commit('1234', 'New Commit');
+	public function test_should_create_commit() {
+		$response = $this->api->create_commit( '1234', 'New Commit' );
 
-		$this->assertCount(2, $this->http_requests);
-		$this->assertEquals('7638417db6d59f3c431d3e1f261cc637155684cd', $response->sha);
+		$this->assertCount( 2, $this->http_requests );
+		$this->assertEquals( '7638417db6d59f3c431d3e1f261cc637155684cd', $response->sha );
 	}
 
-	function test_should_update_master_reference() {
-		$response = $this->api->set_ref('123');
+	public function test_should_update_master_reference() {
+		$response = $this->api->set_ref( '123' );
 
-		$this->assertCount(1, $this->http_requests);
-		$this->assertEquals( "aa218f56b14c9653891f9e74264a383fa43fefbd", $response->object->sha);
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertEquals( 'aa218f56b14c9653891f9e74264a383fa43fefbd', $response->object->sha );
 	}
 
-	function test_should_return_lastest_tree() {
+	public function test_should_return_lastest_tree() {
 		$response = $this->api->last_tree_recursive();
 
-		$this->assertCount(3, $this->http_requests);
-		$this->assertCount(2, $response);
+		$this->assertCount( 3, $this->http_requests );
+		$this->assertCount( 2, $response );
 	}
 
 	/**
 	 * This does some checks and fails the test if something is wrong
 	 * or returns intended mock data for the given endpoint + method
 	 */
-	function mock_github_api( $request, $url ) {
-		if ( substr( $url, 0, 10) !== "github.api" ) {
+	public function mock_github_api( $request, $url ) {
+		if ( 'github.api' !== substr( $url, 0, 10 ) ) {
 			$this->assertTrue( false, "Didn't call the correct host" );
 		}
 
 		$url = explode( '/',  substr( $url, 11 ) );
 
-		if ( $url[0] !== "repos" ) {
+		if ( 'repos' !== $url[0] ) {
 			$this->assertTrue( false, "Didn't call the repos endpoint" );
 		}
 
-		if ( $url[1] !== "person" || $url[2] !== "repo"  ) {
+		if ( 'person' !== $url[1] || 'repo' !== $url[2] ) {
 			$this->assertTrue( false, "Didn't call the correct repo" );
 		}
 
-		if ( "GET" === $request['method'] ) {
-			return $this->mock_get_requests($url[3], $url[4]);
+		if ( 'GET' === $request['method'] ) {
+			return $this->mock_get_requests( $url[3], $url[4] );
 		}
 
-		if ( "POST" === $request['method'] ) {
-			return $this->mock_post_requests($url[3], $url[4], $request['body']);
+		if ( 'POST' === $request['method'] ) {
+			return $this->mock_post_requests( $url[3], $url[4], $request['body'] );
 		}
 	}
 
-	function mock_get_requests( $api, $endpoint ) {
+	public function mock_get_requests( $api, $endpoint ) {
 		$get = array(
-			"git/blobs" => array("body" => '{"content": "Content of the blob","encoding": "utf-8","url": "https://api.github.com/repos/octocat/example/git/blobs/3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","sha": "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","size": 100}'),
-			"git/trees" => array("body" => '{"sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 526,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir","mode": "040000","type": "tree","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir/README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 2227357,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"}],"truncated": false}'),
-			"git/commits" => array("body" => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}'),
-			"git/refs" => array("body" => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}'),
+			'git/blobs' => array( 'body' => '{"content": "Content of the blob","encoding": "utf-8","url": "https://api.github.com/repos/octocat/example/git/blobs/3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","sha": "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15","size": 100}' ),
+			'git/trees' => array( 'body' => '{"sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 526,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir","mode": "040000","type": "tree","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/person/repo/git/trees/fc6274d15fa3ae2ab983129fb037999f264ba9a7"},{"path": "subdir/README.md","mode": "100644","type": "blob","sha": "fc6274d15fa3ae2ab983129fb037999f264ba9a7","size": 2227357,"url": "https://api.github.com/repos/person/repo/git/blobs/fc6274d15fa3ae2ab983129fb037999f264ba9a7"}],"truncated": false}' ),
+			'git/commits' => array( 'body' => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}' ),
+			'git/refs' => array( 'body' => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}' ),
 		);
 
-		$response = $get[ $api . "/" . $endpoint ];
-		$response['headers'] = array( "status" => "200 OK" );
+		$response = $get[ $api . '/' . $endpoint ];
+		$response['headers'] = array( 'status' => '200 OK' );
 
 		return $response;
 	}
 
-	function mock_post_requests( $api, $endpoint, $body ) {
+	public function mock_post_requests( $api, $endpoint, $body ) {
 		$post = array(
-			"git/trees" => array('body'=> '{"sha": "cd8274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/octocat/Hello-World/trees/cd8274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "file.rb","mode": "100644","type": "blob","size": 132,"sha": "7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b","url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b"}]}'),
-			"git/commits" => array("body" => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}'),
-			"git/refs" => array("body" => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}'),
+			'git/trees' => array( 'body' => '{"sha": "cd8274d15fa3ae2ab983129fb037999f264ba9a7","url": "https://api.github.com/repos/octocat/Hello-World/trees/cd8274d15fa3ae2ab983129fb037999f264ba9a7","tree": [{"path": "file.rb","mode": "100644","type": "blob","size": 132,"sha": "7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b","url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/7c258a9869f33c1e1e1f74fbb32f07c86cb5a75b"}]}' ),
+			'git/commits' => array( 'body' => '{"sha":"7638417db6d59f3c431d3e1f261cc637155684cd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd","author":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"committer":{"date":"2010-04-10T14:10:01-07:00","name":"ScottChacon","email":"schacon@gmail.com"},"message":"added readme, because im a good github citizen\n","tree":{"url":"https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb","sha":"691272480426f78a0138979dd3ce63b77f706feb"},"parents":[{"url":"https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5","sha":"1acc419d4d6a9ce985db7be48c6349a0475975b5"}]}' ),
+			'git/refs' => array( 'body' => '{"ref":"refs/heads/featureA","url":"https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA","object":{"type":"commit","sha":"aa218f56b14c9653891f9e74264a383fa43fefbd","url":"https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"}}' ),
 		);
 
-		if ( "trees" === $endpoint ) {
-			$this->assertObjectHasAttribute( 'tree', json_decode($body) );
+		if ( 'trees' === $endpoint ) {
+			$this->assertObjectHasAttribute( 'tree', json_decode( $body ) );
 		}
 
-		if ( "commits" === $endpoint ) {
-			$this->assertObjectHasAttribute( 'message', json_decode($body) );
-			$this->assertObjectHasAttribute( 'author', json_decode($body) );
-			$this->assertObjectHasAttribute( 'tree', json_decode($body) );
-			$this->assertObjectHasAttribute( 'parents', json_decode($body) );
+		if ( 'commits' === $endpoint ) {
+			$this->assertObjectHasAttribute( 'message', json_decode( $body ) );
+			$this->assertObjectHasAttribute( 'author', json_decode( $body ) );
+			$this->assertObjectHasAttribute( 'tree', json_decode( $body ) );
+			$this->assertObjectHasAttribute( 'parents', json_decode( $body ) );
 		}
 
-		if ( "refs" === $endpoint ) {
-			$this->assertObjectHasAttribute( 'sha', json_decode($body) );
+		if ( 'refs' === $endpoint ) {
+			$this->assertObjectHasAttribute( 'sha', json_decode( $body ) );
 		}
 
-		$response = $post[ $api . "/" . $endpoint ];
-		$response['headers'] = array( "status" => "201 CREATED" );
+		$response = $post[ $api . '/' . $endpoint ];
+		$response['headers'] = array( 'status' => '201 CREATED' );
 
 		return $response;
 	}

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -2,11 +2,11 @@
 
 class WordPress_GitHub_Sync_CLI_Test extends WP_UnitTestCase {
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 	}
 
-	function test_something() {
+	public function test_something() {
 		$this->markTestIncomplete();
 	}
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -1,0 +1,13 @@
+<?php
+
+class WordPress_GitHub_Sync_CLI_Test extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+	}
+
+	function test_something() {
+		$this->markTestIncomplete();
+	}
+}
+

--- a/tests/test-controller.php
+++ b/tests/test-controller.php
@@ -2,11 +2,11 @@
 
 class WordPress_GitHub_Sync_Controller_Test extends WP_UnitTestCase {
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 	}
 
-	function test_something() {
+	public function test_something() {
 		$this->markTestIncomplete();
 	}
 }

--- a/tests/test-controller.php
+++ b/tests/test-controller.php
@@ -1,0 +1,13 @@
+<?php
+
+class WordPress_GitHub_Sync_Controller_Test extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+	}
+
+	function test_something() {
+		$this->markTestIncomplete();
+	}
+}
+

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -1,0 +1,13 @@
+<?php
+
+class WordPress_GitHub_Sync_Main_Test extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+	}
+
+	function test_something() {
+		$this->markTestIncomplete();
+	}
+}
+

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -2,11 +2,11 @@
 
 class WordPress_GitHub_Sync_Main_Test extends WP_UnitTestCase {
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 	}
 
-	function test_something() {
+	public function test_something() {
 		$this->markTestIncomplete();
 	}
 }

--- a/tests/test-post.php
+++ b/tests/test-post.php
@@ -4,16 +4,10 @@ class WordPress_GitHub_Sync_Post_Test extends WP_UnitTestCase {
 
 	function setUp() {
 		parent::setUp();
-		$this->id = $this->factory->post->create();
 	}
 
-	function test_should_get_id_by_path() {
-		$path = 'thepath';
-		update_post_meta( $this->id, '_wpghs_github_path', $path );
-
-		$post = new WordPress_GitHub_Sync_Post( $path );
-
-		$this->assertEquals( $this->id, $post->id );
+	function test_something() {
+		$this->markTestIncomplete();
 	}
 }
 

--- a/tests/test-post.php
+++ b/tests/test-post.php
@@ -2,11 +2,11 @@
 
 class WordPress_GitHub_Sync_Post_Test extends WP_UnitTestCase {
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 	}
 
-	function test_something() {
+	public function test_something() {
 		$this->markTestIncomplete();
 	}
 }

--- a/views/options.php
+++ b/views/options.php
@@ -1,20 +1,20 @@
 <div class="wrap">
-  <h2><?php _e( "WordPress <--> GitHub Sync", WordPress_GitHub_Sync::$text_domain ); ?></h2>
-  <form method="post" action="options.php">
-    <?php settings_fields( WordPress_GitHub_Sync::$text_domain ); ?>
-    <?php do_settings_sections( WordPress_GitHub_Sync::$text_domain ); ?>
-    <table class="form-table">
-      <tr>
-        <th scope="row"><?php _e( "Webhook callback", WordPress_GitHub_Sync::$text_domain ); ?></th>
-        <td><code><?php echo admin_url( 'admin-ajax.php' ); ?>?action=wpghs_sync_request</code></td>
-      </tr>
-      <tr>
-        <th scope="row"><?php _e( "Bulk actions", WordPress_GitHub_Sync::$text_domain ); ?></th>
-        <td>
-          <a href="<?php echo add_query_arg( array( "action" => "export" ) ) ?>"><?php _e( "Export to GitHub", WordPress_GitHub_Sync::$text_domain ); ?></a> |
-          <a href="<?php echo add_query_arg( array( "action" => "import" ) ) ?>"><?php _e( "Import from GitHub", WordPress_GitHub_Sync::$text_domain ); ?></a>
-        </td>
-    </table>
-    <?php submit_button(); ?>
-  </form>
+	<h2><?php _e( 'WordPress <--> GitHub Sync', WordPress_GitHub_Sync::$text_domain ); ?></h2>
+	<form method="post" action="options.php">
+		<?php settings_fields( WordPress_GitHub_Sync::$text_domain ); ?>
+		<?php do_settings_sections( WordPress_GitHub_Sync::$text_domain ); ?>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php _e( 'Webhook callback', WordPress_GitHub_Sync::$text_domain ); ?></th>
+				<td><code><?php echo admin_url( 'admin-ajax.php' ); ?>?action=wpghs_sync_request</code></td>
+			</tr>
+			<tr>
+				<th scope="row"><?php _e( 'Bulk actions', WordPress_GitHub_Sync::$text_domain ); ?></th>
+				<td>
+					<a href="<?php echo add_query_arg( array( 'action' => 'export' ) ) ?>"><?php _e( 'Export to GitHub', WordPress_GitHub_Sync::$text_domain ); ?></a> |
+					<a href="<?php echo add_query_arg( array( 'action' => 'import' ) ) ?>"><?php _e( 'Import from GitHb', WordPress_GitHub_Sync::$text_domain ); ?></a>
+				</td>
+		</table>
+		<?php submit_button(); ?>
+	</form>
 </div>

--- a/views/setting-field.php
+++ b/views/setting-field.php
@@ -1,3 +1,3 @@
-<?php $value = get_option($args["name"], $args["default"] ); ?>
-<input name="<?php echo esc_attr($args["name"]) ?>" id="<?php echo esc_attr($args["name"]) ?>" type="text" value="<?php echo esc_attr($value) ?>" />
-<p class="description"><?php echo $args["help_text"] ?></p>
+<?php $value = get_option( $args['name'], $args['default'] ); ?>
+<input name="<?php echo esc_attr( $args['name'] ) ?>" id="<?php echo esc_attr( $args['name'] ) ?>" type="text" value="<?php echo esc_attr( $value ) ?>" />
+<p class="description"><?php echo $args['help_text'] ?></p>

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -11,193 +11,228 @@
  * Text Domain: wordpress-github-sync
  */
 
- /*  Copyright 2014  Ben Balter  (email : ben@balter.com)
+/*  Copyright 2014  Ben Balter  (email : ben@balter.com)
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
+		This program is free software; you can redistribute it and/or modify
+		it under the terms of the GNU General Public License, version 2, as
+		published by the Free Software Foundation.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+		This program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+		You should have received a copy of the GNU General Public License
+		along with this program; if not, write to the Free Software
+		Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 
 class WordPress_GitHub_Sync {
 
-    static $instance;
-    static $text_domain = "wordpress-github-sync";
-    static $version = "0.0.1";
-    public $push_lock = false;
+	/**
+	 * Object instance
+	 * @var self
+	 */
+	public static $instance;
 
-    /**
-     * Called at load time, hooks into WP core
-     */
-    function __construct() {
-      self::$instance = &$this;
+	/**
+	 * Language text domain
+	 * @var string
+	 */
+	public static $text_domain = 'wordpress-github-sync';
 
-      if (is_admin()) {
-        $this->admin = new WordPress_GitHub_Sync_Admin;
-      }
-      $this->controller = new WordPress_GitHub_Sync_Controller;
+	/**
+	 * Current version
+	 * @var string
+	 */
+	public static $version = '0.0.1';
 
-      add_action( 'init', array( &$this, 'l10n' ) );
-      add_action( 'save_post', array( &$this, 'save_post_callback' ) );
-      add_action( 'delete_post', array( &$this, 'delete_post_callback' ) );
-      add_action( 'wp_ajax_nopriv_wpghs_sync_request', array( &$this, 'pull_posts' ));
-      add_action( 'wpghs_export', array( &$this->controller, 'export_all' ) );
-      add_action( 'wpghs_import', array( &$this->controller, 'import_master' ) );
+	/**
+	 * Controller object
+	 * @var WordPress_GitHub_Sync_Controller
+	 */
+	public $controller;
 
-      if ( defined('WP_CLI') && WP_CLI ) {
-        WP_CLI::add_command( 'wpghs', 'WordPress_GitHub_Sync_CLI' );
-      }
-    }
+	/**
+	 * Controller object
+	 * @var WordPress_GitHub_Sync_Admin
+	 */
+	public $admin;
 
-    /**
-      * Init i18n files
-      */
-    function l10n() {
-      load_plugin_textdomain( self::$text_domain, false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
-    }
+	/**
+	 * Locked when receiving payload
+	 * @var boolean
+	 */
+	public $push_lock = false;
 
-    /**
-     * Returns the Webhook secret
-     */
-    function secret() {
-      return get_option( "wpghs_secret" );
-    }
+	/**
+	 * Called at load time, hooks into WP core
+	 */
+	public function __construct() {
+		self::$instance = &$this;
 
-    /**
-     * Callback triggered on post save, used to initiate an outbound sync
-     *
-     * $post_id - (int) the post to sync
-     */
-    function save_post_callback($post_id) {
+		if ( is_admin() ) {
+			$this->admin = new WordPress_GitHub_Sync_Admin;
+		}
+		$this->controller = new WordPress_GitHub_Sync_Controller;
 
-      if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) )
-        return;
+		add_action( 'init', array( &$this, 'l10n' ) );
+		add_action( 'save_post', array( &$this, 'save_post_callback' ) );
+		add_action( 'delete_post', array( &$this, 'delete_post_callback' ) );
+		add_action( 'wp_ajax_nopriv_wpghs_sync_request', array( &$this, 'pull_posts' ) );
+		add_action( 'wpghs_export', array( &$this->controller, 'export_all' ) );
+		add_action( 'wpghs_import', array( &$this->controller, 'import_master' ) );
 
-      // Right now CPTs are not supported
-      if (get_post_type($post_id) != "page" && get_post_type($post_id) != "post") {
-        return;
-      }
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'wpghs', 'WordPress_GitHub_Sync_CLI' );
+		}
+	}
 
-      // Not yet published
-      if (get_post_status( $post_id ) != "publish")
-        return;
+	/**
+		* Init i18n files
+		*/
+	public function l10n() {
+		load_plugin_textdomain( self::$text_domain, false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
+	}
 
-      $this->controller->export_post($post_id);
+	/**
+	 * Returns the Webhook secret
+	 */
+	public function secret() {
+		return get_option( 'wpghs_secret' );
+	}
 
-    }
+	/**
+	 * Callback triggered on post save, used to initiate an outbound sync
+	 *
+	 * $post_id - (int) the post to sync
+	 */
+	public function save_post_callback($post_id) {
 
-    /**
-     * Callback triggered on post delete, used to initiate an outbound sync
-     *
-     * $post_id - (int) the post to delete
-     */
-    function delete_post_callback( $post_id ) {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
 
-      $post = get_post($post_id);
+		// Right now CPTs are not supported
+		if ( 'page' !== get_post_type( $post_id ) && 'post' !== get_post_type( $post_id ) ) {
+			return;
+		}
 
-      // Right now CPTs are not supported
-      if ($post->post_type != "page" && $post->post_type != "post")
-        return;
+		// Not yet published
+		if ( 'publish' !== get_post_status( $post_id ) ) {
+			return;
+		}
 
-      $this->controller->delete_post($post_id);
+		$this->controller->export_post( $post_id );
 
-    }
+	}
 
-    /**
-     * Webhook callback as trigered from GitHub push
-     */
-    function pull_posts() {
-      # Prevent pushes on update
-      $this->push_lock = true;
+	/**
+	 * Callback triggered on post delete, used to initiate an outbound sync
+	 *
+	 * $post_id - (int) the post to delete
+	 */
+	public function delete_post_callback( $post_id ) {
 
-      $raw_data = file_get_contents('php://input');
-      $headers = $this->headers();
+		$post = get_post( $post_id );
 
-      // validate secret
-      $hash = hash_hmac( "sha1", $raw_data, $this->secret() );
-      if ( $headers["X-Hub-Signature"] != "sha1=" . $hash ) {
-        self::write_log( __("Failed to validate secret.", WordPress_GitHub_Sync::$text_domain) );
-        die();
-      }
+		// Right now CPTs are not supported
+		if ( 'page' !== $post->post_type && 'post' !== $post->post_type ) {
+			return;
+		}
 
-      $this->controller->pull(json_decode($raw_data));
-      die();
-    }
+		$this->controller->delete_post( $post_id );
 
-    /**
-     * Cross-server header support
-     * Returns an array of the request's headers
-     */
-    function headers() {
-      if (function_exists('getallheaders'))
-        return getallheaders();
+	}
 
-      // Nginx and pre 5.4 workaround
-      // http://www.php.net/manual/en/function.getallheaders.php
-      $headers = array();
-      foreach ($_SERVER as $name => $value) {
-       if (substr($name, 0, 5) == 'HTTP_') {
-         $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
-       }
-      }
-      return $headers;
-    }
+	/**
+	 * Webhook callback as trigered from GitHub push
+	 */
+	public function pull_posts() {
+		# Prevent pushes on update
+		$this->push_lock = true;
 
-    /**
-     * Sets and kicks off the export cronjob
-     */
-    function start_export() {
-      update_option( '_wpghs_export_user_id', get_current_user_id() );
-      update_option( '_wpghs_export_started', 'yes' );
+		$raw_data = file_get_contents( 'php://input' );
+		$headers = $this->headers();
 
-      WordPress_GitHub_Sync::write_log( __( "Starting full export to GitHub.", WordPress_GitHub_Sync::$text_domain ) );
+		// validate secret
+		$hash = hash_hmac( 'sha1', $raw_data, $this->secret() );
+		if ( 'sha1=' . $hash !== $headers['X-Hub-Signature'] ) {
+			self::write_log( __( 'Failed to validate secret.', WordPress_GitHub_Sync::$text_domain ) );
+			die();
+		}
 
-      wp_schedule_single_event(time(), 'wpghs_export');
-      spawn_cron();
-    }
+		$this->controller->pull( json_decode( $raw_data ) );
+		die();
+	}
 
-    /**
-     * Sets and kicks off the import cronjob
-     */
-    function start_import() {
-      update_option( '_wpghs_import_started', 'yes' );
+	/**
+	 * Cross-server header support
+	 * Returns an array of the request's headers
+	 */
+	public function headers() {
+		if ( function_exists( 'getallheaders' ) ) {
+			return getallheaders();
+		}
 
-      WordPress_GitHub_Sync::write_log( __( "Starting import from GitHub.", WordPress_GitHub_Sync::$text_domain ) );
+		// Nginx and pre 5.4 workaround
+		// http://www.php.net/manual/en/function.getallheaders.php
+		$headers = array();
+		foreach ( $_SERVER as $name => $value ) {
+			if ( 'HTTP_' === substr( $name, 0, 5 ) ) {
+				$headers[ str_replace( ' ', '-', ucwords( strtolower( str_replace( '_', ' ', substr( $name, 5 ) ) ) ) ) ] = $value;
+			}
+		}
+		return $headers;
+	}
 
-      wp_schedule_single_event(time(), 'wpghs_import');
-      spawn_cron();
-    }
+	/**
+	 * Sets and kicks off the export cronjob
+	 */
+	public function start_export() {
+		update_option( '_wpghs_export_user_id', get_current_user_id() );
+		update_option( '_wpghs_export_started', 'yes' );
 
-    /**
-     * Print to WP_CLI if in CLI environment or
-     * write to debug.log if WP_DEBUG is enabled
-     * @source http://www.stumiller.me/sending-output-to-the-wordpress-debug-log/
-     */
-    static function write_log($msg, $write = 'line') {
-      if ( defined('WP_CLI') && WP_CLI ) {
-        if ( is_array( $msg ) || is_object( $msg ) ) {
-          WP_CLI::print_value( $msg );
-        } else {
-          WP_CLI::$write( $msg );
-        }
-      } elseif ( true === WP_DEBUG ) {
-        if ( is_array( $msg ) || is_object( $msg ) ) {
-          error_log( print_r( $msg, true ) );
-        } else {
-          error_log( $msg );
-        }
-      }
-    }
+		WordPress_GitHub_Sync::write_log( __( 'Starting full export to GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+
+		wp_schedule_single_event( time(), 'wpghs_export' );
+		spawn_cron();
+	}
+
+	/**
+	 * Sets and kicks off the import cronjob
+	 */
+	public function start_import() {
+		update_option( '_wpghs_import_started', 'yes' );
+
+		WordPress_GitHub_Sync::write_log( __( 'Starting import from GitHub.', WordPress_GitHub_Sync::$text_domain ) );
+
+		wp_schedule_single_event( time(), 'wpghs_import' );
+		spawn_cron();
+	}
+
+	/**
+	 * Print to WP_CLI if in CLI environment or
+	 * write to debug.log if WP_DEBUG is enabled
+	 * @source http://www.stumiller.me/sending-output-to-the-wordpress-debug-log/
+	 */
+	public static function write_log($msg, $write = 'line') {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			if ( is_array( $msg ) || is_object( $msg ) ) {
+				WP_CLI::print_value( $msg );
+			} else {
+				WP_CLI::$write( $msg );
+			}
+		} elseif ( true === WP_DEBUG ) {
+			if ( is_array( $msg ) || is_object( $msg ) ) {
+				error_log( print_r( $msg, true ) );
+			} else {
+				error_log( $msg );
+			}
+		}
+	}
 }
 
 $wpghs = new WordPress_GitHub_Sync;

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -52,6 +52,7 @@ class WordPress_GitHub_Sync {
       add_action( 'delete_post', array( &$this, 'delete_post_callback' ) );
       add_action( 'wp_ajax_nopriv_wpghs_sync_request', array( &$this, 'pull_posts' ));
       add_action( 'wpghs_export', array( &$this->controller, 'export_all' ) );
+      add_action( 'wpghs_import', array( &$this->controller, 'import_master' ) );
 
       if ( defined('WP_CLI') && WP_CLI ) {
         WP_CLI::add_command( 'wpghs', 'WordPress_GitHub_Sync_CLI' );
@@ -153,7 +154,7 @@ class WordPress_GitHub_Sync {
     }
 
     /**
-     * Get posts to export, set and kick off cronjob
+     * Sets and kicks off the export cronjob
      */
     function start_export() {
       update_option( '_wpghs_export_user_id', get_current_user_id() );
@@ -162,6 +163,18 @@ class WordPress_GitHub_Sync {
       WordPress_GitHub_Sync::write_log( __( "Starting full export to GitHub.", WordPress_GitHub_Sync::$text_domain ) );
 
       wp_schedule_single_event(time(), 'wpghs_export');
+      spawn_cron();
+    }
+
+    /**
+     * Sets and kicks off the import cronjob
+     */
+    function start_import() {
+      update_option( '_wpghs_import_started', 'yes' );
+
+      WordPress_GitHub_Sync::write_log( __( "Starting import from GitHub.", WordPress_GitHub_Sync::$text_domain ) );
+
+      wp_schedule_single_event(time(), 'wpghs_import');
       spawn_cron();
     }
 

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -103,14 +103,13 @@ class WordPress_GitHub_Sync {
       if ( ! $this->oauth_token() || ! $this->repository() )
         return;
 
-      $post = get_post($post_id);
-
       // Right now CPTs are not supported
-      if ($post->post_type != "page" && $post->post_type != "post")
+      if (get_post_type($post_id) != "page" && get_post_type($post_id) != "post") {
         return;
+      }
 
       // Not yet published
-      if ($post->post_status != "publish")
+      if (get_post_status( $post_id ) != "publish")
         return;
 
       $post = new WordPress_GitHub_Sync_Post($post_id);
@@ -207,6 +206,7 @@ class WordPress_GitHub_Sync {
      * Get posts to export, set and kick off cronjob
      */
     function start_export() {
+      update_option( '_wpghs_export_user_id', get_current_user_id() );
       $this->controller->start();
     }
 


### PR DESCRIPTION
This is going to be a big change, so we should test this thoroughly before merging. It's also definitely going to be backwards breaking.

* [x] Export full site as single commit
* [x] Export full site via WP_CLI command
* [x] Export individual updates/deletes via Git data instead of Content API
* [x] Import Webhook payloads via Git data API
  * [x] Fixes #18
  * [x] Fixes #15 (skips all files w/o front matter)
* [x] Wire up import button and WP-CLI import command
* [x] Improve error handling when calling the API
* [x] Fix #3
* [x] Fix #11
* [x] Fix #23 (Maybe?)