### PR TITLE
Add Scrutinizer, Editorconfig, & Travis coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,13 @@
+tools:
+    php_sim: true
+    php_pdepend: true
+    php_analyzer: true
+    php_code_sniffer:
+        config:
+            standard: WordPress
+    external_code_coverage:
+        timeout: 1200
+        runs: 1
+filter:
+    excluded_paths:
+        - 'test/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,8 @@ before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - composer install
 
-script: phpunit
+after_script:
+    - wget https://scrutinizer-ci.com/ocular.phar
+    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+script: phpunit --coverage-clover=coverage.clover

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,4 +11,9 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<blacklist>
+			<directory>/tmp/wordpress*</directory>
+		</blacklist>
+	</filter>
 </phpunit>


### PR DESCRIPTION
Let me know if I'm imposing my workflow on you, but this adds some of the tools I use to help me keep aligned with a standard. The only thing is WPCS calls for tabs, not spaces, so I can change .editorconfig to match that if you prefer spaces.