### PR TITLE
Typos breaking pushing to GitHub.

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -246,7 +246,7 @@ class WordPress_GitHub_Sync_Post {
     $content = base64_decode($data->content);
 
     // Break out meta, if present
-    preg_match( "/(^---(.*)---$)?(.*)/ms", $content, $matches );
+    preg_match( "/(^---(.*?)---$)?(.*)/ms", $content, $matches );
 
     $body = array_pop( $matches );
 

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -100,7 +100,7 @@ class WordPress_GitHub_Sync {
         return;
 
       if ( ! $this->oauth_token() || ! $this->repository() )
-        return
+        return;
 
       $post = get_post($post_id);
 
@@ -125,7 +125,7 @@ class WordPress_GitHub_Sync {
     function delete_post_callback( $post_id ) {
 
       if ( ! $this->oauth_token() || ! $this->repository() )
-        return
+        return;
 
       $post = get_post($post_id);
 


### PR DESCRIPTION
Looks like a straightforward case of two semicolons going missing at some point.  They break pushing and deleting because $post remains null, so the subsequent tests of $post->post_type fails.