### PR TITLE
Add custom post_type and post_status support

### DIFF
--- a/lib/controller.php
+++ b/lib/controller.php
@@ -267,7 +267,7 @@ class WordPress_GitHub_Sync_Controller {
 			post_type IN ( $post_types )"
 		);
 
-		$this->msg = 'Full export from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+		$this->msg = apply_filters( 'wpghs_commit_msg_full', 'Full export from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ')' ) .  ' - wpghs';
 
 		$this->get_tree();
 
@@ -291,7 +291,7 @@ class WordPress_GitHub_Sync_Controller {
 
 		$this->posts[] = $post_id;
 		$post = new WordPress_GitHub_Sync_Post( $post_id );
-		$this->msg = 'Syncing ' . $post->github_path() . ' from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+		$this->msg = apply_filters( 'wpghs_commit_msg_single', 'Syncing ' . $post->github_path() . ' from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ')', $post ) .  ' - wpghs';
 
 		$this->get_tree();
 
@@ -311,7 +311,7 @@ class WordPress_GitHub_Sync_Controller {
 
 		$this->posts[] = $post_id;
 		$post = new WordPress_GitHub_Sync_Post( $post_id );
-		$this->msg = 'Deleting ' . $post->github_path() . ' via WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
+		$this->msg = apply_filters( 'wpghs_commit_msg_delete', 'Deleting ' . $post->github_path() . ' via WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ')', $post ) .  ' - wpghs';
 
 		$this->get_tree();
 

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -162,12 +162,14 @@ class WordPress_GitHub_Sync_Controller {
 		}
 
 		// If the blob sha already matches a post, then move on
+		// @TODO: check if we moved this post from one directory to another, so that we need to update the post type.
 		$id = $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_sha' AND meta_value = '$blob->sha'" );
 		if ( $id ) {
 			WordPress_GitHub_Sync::write_log( __( 'Already synced blob ', WordPress_GitHub_Sync::$text_domain ) . $blob->path );
 			return;
 		}
 
+		$path = $blob->path;
 		$blob = $this->api->get_blob( $blob->sha );
 
 		if ( is_wp_error( $blob ) ) {
@@ -201,17 +203,28 @@ class WordPress_GitHub_Sync_Controller {
 			$body = wpmarkdown_markdown_to_html( $body );
 		}
 
+		$post = new WordPress_GitHub_Sync_Post( $args['ID'] );
+
 		// Can we really just mash everything together here?
+		$post_type = $post->get_type_from_path($path);
+		$post_name = $post->get_name_from_path($path);
 		$args = array_merge( $meta, array(
-			'post_content' => $body,
-			'_sha'         => $blob->sha,
+			'post_type'    => $post_type,
+			'post_name'    => $post_name,
+			'post_content' => $body
 		) );
 
-		if ( ! isset($args['ID']) ) {
-			wp_insert_post( $args );
-		} else {
-			wp_update_post( $args );
+		if ( $post->is_post_type_blacklisted($post_type) ) {
+			return;
 		}
+
+		if ( ! isset($args['ID']) ) {
+			$post_id = wp_insert_post( $args );
+		} else {
+			$post_id = wp_update_post( $args );
+		}
+
+		$post->set_sha($blob->sha, $post_id);
 	}
 
 	/**
@@ -224,7 +237,9 @@ class WordPress_GitHub_Sync_Controller {
 			return;
 		}
 
-		$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ('post', 'page' )" );
+		$post = new WordPress_GitHub_Sync_Post(0);
+		$blacklisted_post_types = $post->get_blacklisted_values();
+		$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_type NOT IN ( $blacklisted_post_types )" );
 		$this->msg = 'Full export from WordPress at ' . site_url() . ' (' . get_bloginfo( 'name' ) . ') - wpghs';
 
 		$this->get_tree();
@@ -289,6 +304,7 @@ class WordPress_GitHub_Sync_Controller {
 
 		foreach ( $this->tree as $index => $blob ) {
 			if ( ! isset( $blob->sha ) ) {
+
 				continue;
 			}
 

--- a/lib/controller.php
+++ b/lib/controller.php
@@ -217,6 +217,9 @@ class WordPress_GitHub_Sync_Controller {
 			$args['post_type'] = $meta['layout'];
 			unset( $meta['layout'] );
 
+			$args['post_status'] = true === $meta['published'] ? 'publish' : 'draft';
+			unset( $meta['published'] );
+
 			if ( isset( $meta['ID'] ) ) {
 				$args['ID'] = $meta['ID'];
 				unset( $meta['ID'] );

--- a/lib/post.php
+++ b/lib/post.php
@@ -165,7 +165,7 @@ class WordPress_GitHub_Sync_Post {
 			}
 		}
 
-		return apply_filters( 'wpghs_content', $content );
+		return $content;
 	}
 
 	/**

--- a/lib/post.php
+++ b/lib/post.php
@@ -174,7 +174,11 @@ class WordPress_GitHub_Sync_Post {
 	 * Returns (string) the path relative to repo root
 	 */
 	public function github_path() {
-		return $this->github_directory() . $this->github_filename();
+		$path = $this->github_directory() . $this->github_filename();
+
+		update_post_meta( $this->id, '_wpghs_github_path', $path );
+
+		return $path;
 	}
 
 	/**

--- a/lib/post.php
+++ b/lib/post.php
@@ -294,6 +294,7 @@ class WordPress_GitHub_Sync_Post {
 			'post_excerpt' => $this->post->post_excerpt,
 			'layout'       => get_post_type( $this->post ),
 			'permalink'    => get_permalink( $this->post ),
+			'published'    => 'publish' === $this->status ? true : false,
 		);
 
 		//convert traditional post_meta values, hide hidden values

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -109,25 +109,12 @@ class WordPress_GitHub_Sync {
 	 *
 	 * $post_id - (int) the post to sync
 	 */
-	public function save_post_callback($post_id) {
-
+	public function save_post_callback( $post_id ) {
 		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
 			return;
 		}
 
-		// Right now CPTs are not supported
-		$post = new WordPress_GitHub_Sync_Post( $post_id );
-		if ($post->is_post_type_blacklisted()) {
-			return;
-		}
-
-		// Not yet published
-		if ( 'publish' !== get_post_status( $post_id ) ) {
-			return;
-		}
-
 		$this->controller->export_post( $post_id );
-
 	}
 
 	/**
@@ -136,17 +123,11 @@ class WordPress_GitHub_Sync {
 	 * $post_id - (int) the post to delete
 	 */
 	public function delete_post_callback( $post_id ) {
-
-		$post = get_post( $post_id );
-
-		// Right now CPTs are not supported
-		$post = new WordPress_GitHub_Sync_Post( $post_id );
-		if ($post->is_post_type_blacklisted()) {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
 			return;
 		}
 
 		$this->controller->delete_post( $post_id );
-
 	}
 
 	/**

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -116,7 +116,8 @@ class WordPress_GitHub_Sync {
 		}
 
 		// Right now CPTs are not supported
-		if ( 'page' !== get_post_type( $post_id ) && 'post' !== get_post_type( $post_id ) ) {
+		$post = new WordPress_GitHub_Sync_Post( $post_id );
+		if ($post->is_post_type_blacklisted()) {
 			return;
 		}
 
@@ -139,7 +140,8 @@ class WordPress_GitHub_Sync {
 		$post = get_post( $post_id );
 
 		// Right now CPTs are not supported
-		if ( 'page' !== $post->post_type && 'post' !== $post->post_type ) {
+		$post = new WordPress_GitHub_Sync_Post( $post_id );
+		if ($post->is_post_type_blacklisted()) {
 			return;
 		}
 


### PR DESCRIPTION
Supersedes and closes #53. Closes #52 & #6.

Couple notes:

1. Thanks again to @WellingGuzman for getting started on this.
2. I've changed the original implementation to make it opt-in. When I was testing on my personal site, I found some old posts from removed plugins as well as posts from current plugins that I wouldn't necessarily want to export. It's opt-in via filters; same with alternate post status support.
3. Right now, on import, we're not filtering. I'm kinda thinking if it's public (on GitHub) and a user updates it, they want it synced, even if the post_type isn't getting exported anymore. I think the idea behind whitelisting is to only let what the user wants out. Otherwise, once it's out, I'm not sure it matters, but I'm open to being convinced if there's a use I'm not thinking of.
3. Post-1.0.0, the controller needs to be refactored to make it smaller. This is getting hard to manage and can probably be split into 3 classes (one for import, one for export, with the main controller doing the validation and filtering out unsupported posts).
4. Additionally, we could also add settings to make post_type/post_statuses enable-able on the front-end, though part of me prefers forcing people to do it through code.