### PR TITLE
Replace array_map+closure with foreach to support PHP 5.2. Resolves #62.

### DIFF
--- a/lib/controller.php
+++ b/lib/controller.php
@@ -537,9 +537,10 @@ class WordPress_GitHub_Sync_Controller {
 	 * @return string            Whitelist formatted for query
 	 */
 	protected function format_for_query( $whitelist ) {
-		return implode(', ', array_map( function( $v ) {
-			return "'$v'";
-		}, $whitelist ) );
+		foreach( $whitelist as $key => $value ) {
+			$whitelist[ $key ] = "'$value'";
+		}
+		return implode( ', ', $whitelist );
 	}
 
 	/**


### PR DESCRIPTION
[array_map](http://php.net/manual/en/function.array-map.php) is using a closure to modify members of the `$whitelist` array. This `foreach` loop achieves the same behavior in 4 lines, rather than 3.

Because the `foreach` only runs one line, enclosing brackets could be removed. I have kept them to keep with WordPress coding standards.

This should enable PHP 5.2 support.