### PR TITLE
Rewrite caching object to use Transients.

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -1,69 +1,102 @@
 <?php
+
 /**
  * The cache object which reads and writes the GitHub api data
  */
 class WordPress_GitHub_Sync_Cache {
 
 	/**
-	 * Endpoints to cache
+	 * Endpoint types to cache.
 	 */
 	protected $blobs = array();
 	protected $trees = array();
 	protected $commits = array();
 
 	/**
-	 * Object instance
+	 * Object instance.
 	 * @var self
 	 */
-	public static $instance;
+	protected static $instance;
 
 	/**
-	 * Retrieves the api cache data and loads it into the object
+	 * Clean out previous version of API data.
+	 *
+	 * This old data failed to save frequently, as it was too much data to
+	 * hold in a single MySQL row. While the idea of maintaining this data
+	 * permanently in the database seemed ideal, given that the response for
+	 * a given sha of a given type will never change, it was too much information.
+	 * Transients are much more appropriate for this type of data, and even if we lose it,
+	 * it can still be refetched from the GitHub API.
+	 *
+	 * The structure of this object, including the name `open` for the singleton
+	 * method, is a holdover from this original implementation, where we would save
+	 * to the the database on the WordPress's shutdown hook with a `close` method.
+	 * All of this no longer exists, but we should be good WordPress citizens
+	 * and delete the data we left behind, since it was large and we're no longer
+	 * using it.
 	 */
-	public function __construct() {
-		$cache = get_option( '_wpghs_api_cache', array() );
-
-		if ( ! empty( $cache ) ) {
-			$this->blobs = $cache['blobs'];
-			$this->trees = $cache['trees'];
-			$this->commits = $cache['commits'];
+	protected function __construct() {
+		// clear out previously saved information
+		if ( get_option( '_wpghs_api_cache' ) ) {
+			delete_option( '_wpghs_api_cache' );
 		}
-
-		add_action( 'shutdown', array( $this, 'close' ) );
 	}
 
 	/**
-	 * Retrieve data from previous api calls by sha
+	 * Retrieve data from previous api calls by sha.
+	 *
+	 * @param string $type
+	 * @param string $sha
+	 *
+	 * @return stdClass|false response object if cached, false if not
 	 */
 	public function get( $type, $sha ) {
-		return isset( $this->{$type}[ $sha ] ) ? $this->{$type}[ $sha ] : false;
+		if ( isset( $this->{$type}[ $sha ] ) ) {
+			return $this->{$type}[ $sha ];
+		}
+
+		if ( $data = get_transient( $this->cache_id( $type, $sha ) ) ) {
+			$this->{$type}[ $sha ] = $data;
+
+			return $data;
+		}
+
+		return false;
 	}
 
 	/**
-	 * Save data from api call by sha
+	 * Save data from api call by sha.
+	 *
+	 * @param string $type
+	 * @param string $sha
+	 * @param mixed $data
+	 *
+	 * @return mixed
 	 */
 	public function save( $type, $sha, $data ) {
 		$this->{$type}[ $sha ] = $data;
+
+		set_transient( $this->cache_id( $type, $sha ), $data );
 
 		return $data;
 	}
 
 	/**
-	 * Saves the cache data right before the object is destroyed
+	 * Generates the cache id for a given type & sha.
+	 *
+	 * @param string $type
+	 * @param string $sha
+	 *
+	 * @return string
 	 */
-	public function close() {
-		$cache = array(
-			'blobs' => $this->blobs,
-			'trees' => $this->trees,
-			'commits' => $this->commits,
-		);
-
-		update_option( '_wpghs_api_cache', $cache );
+	protected function cache_id( $type, $sha ) {
+		return '_wpghs_' . $type . '_' . $sha;
 	}
 
 	/**
-	 * Initializes or retrieves the cache object
-	 * @return Cache object
+	 * Initializes or retrieves the cache object.
+	 *
+	 * @return self
 	 */
 	public static function open() {
 


### PR DESCRIPTION
The other alternative would be to write a better method for distributing this data across many/several/lots of database rows, but that seems like a lot of database hits when we can allow the object cache to manage this for us. WordPress falls back to using the database for transients if there is no persistent object cache installed, so letting WordPress handle all this for us makes sense.

Fixes #72.