### PR TITLE
Unit test documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,48 @@
 
 ## Ways to contribute
 
-1. Grab [an open issue](https://github.com/benbalter/wordpress-github-sync/issues) and [submit a pull request](#submit-a-pull-request)
-2. Try the plugin out on a test server and [report any issues you find](https://github.com/benbalter/wordpress-github-sync/issues/new)
-3. Let us know [what features you'd love to see](https://github.com/benbalter/wordpress-github-sync/issues/new)
-4. Participate in the [discussion forums](https://github.com/benbalter/wordpress-github-sync/issues)
-5. Help improve [the documentation](https://github.com/benbalter/wordpress-github-sync/blob/master/README.md)
-6. Translate the plugin [to another language](https://github.com/benbalter/wordpress-github-sync/tree/master/languages)
+1. Grab [an open issue] and [submit a pull request].
+1. Try the plugin out on a test server and [report any issues you find].
+1. Let us know [what features you'd love to see].
+1. Participate in the [discussion forums].
+1. Help improve [the documentation].
+1. Translate the plugin [to another language].
 
 ## Submit a pull request
 
-Want to propose a change? Great. We could use the help. Here's how:
+Want to propose a change? Great! We could use the help. Here's how:
 
-1. Fork the project
-2. Create a descriptively named feature branch
-3. Commit your changes
-4. Submit a pull request
+1. Fork the project.
+1. Create a descriptively named feature branch.
+1. Commit your changes.
+1. Submit a pull request.
 
-For more information see [GitHub flow](https://guides.github.com/introduction/flow/) and [Contributing to Open Source](https://guides.github.com/activities/contributing-to-open-source/)
+For more information see [GitHub flow] and [Contributing to Open Source].
+
+This project uses [Composer] for dependency management, and there are a few scripts you use to help you along:
+
+* `composer test` will run PHPUnit for you, making sure all your tests pass.
+* `composer sniff` will run the code-sniffer for you, making sure you're adhering to the [WordPress Coding Standards]
+
+In order to the the plugin unit tests, you'll need [MySQL] installed on your development machine. Before running `composer test`, run:
+
+```bash
+bash bin/install-wp-tests.sh <database_name> <username> <password>
+```
+
+where `<username>` and `<password>` are for the root MySQL user. A new database will be created matching `<database_name>`, if it doesn't exist. This database will be deleted every time the tests are run, so `wordpress_test` is commonly used as the database name. 
+
+If you're opening a pull request with a new feature, please include unit tests. If you don't know how to write unit tests, open the PR anyway; we'll be glad to help you out.
+
+  [an open issue]: https://github.com/benbalter/wordpress-github-sync/issues
+  [submit a pull request]: #submit-a-pull-request
+  [report any issues you find]: https://github.com/benbalter/wordpress-github-sync/issues/new
+  [what features you'd love to see]: https://github.com/benbalter/wordpress-github-sync/issues/new
+  [discussion forums]: https://github.com/benbalter/wordpress-github-sync/issues
+  [the documentation]: https://github.com/benbalter/wordpress-github-sync/blob/master/README.md
+  [to another language]: https://github.com/benbalter/wordpress-github-sync/tree/master/languages
+  [GitHub flow]: https://guides.github.com/introduction/flow/
+  [Contributing to Open Source]: https://guides.github.com/activities/contributing-to-open-source/
+  [Composer]: https://getcomposer.org/
+  [WordPress Coding Standards]: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/
+  [MySQL]: https://www.mysql.com/

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,14 @@
     "jdgrimes/wp-http-testcase": "1.2.1",
     "mockery/mockery": "0.9.3",
     "phpunit/phpunit": "^4.8",
-    "websharks/wp-i18n-tools": "dev-master"
+    "websharks/wp-i18n-tools": "dev-master",
+    "wp-coding-standards/wpcs": "0.7.1",
+    "squizlabs/php_codesniffer": "~2.3"
   },
   "scripts": {
+    "sniff": "phpcs --runtime-set installed_paths vendor/wp-coding-standards/wpcs -p ./ --standard=WordPress-Extra --report=full --extensions=php --ignore=*/tests/*,*/vendor/*",
+    "clean": "phpcbf --runtime-set installed_paths vendor/wp-coding-standards/wpcs -p ./ --standard=WordPress-Extra --report=full --extensions=php --ignore=*/tests/*,*/vendor/*",
+    "test": "phpunit",
     "genpot": "vendor/websharks/wp-i18n-tools/makepot.php wp-plugin . $(pwd)/languages/wordpress-github-sync.pot",
     "post-install-cmd": [
       "xrstf\\Composer52\\Generator::onPostInstallCmd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1b1d3dc9f4a2647259d2f9ecafd351ce",
+    "hash": "7395d9a03d63289b05af782252c02f7f",
     "packages": [
         {
             "name": "maadhattah/cyps",
@@ -1092,6 +1092,80 @@
             "time": "2015-06-21 13:59:46"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
+                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2015-09-09 00:18:50"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v2.7.4",
             "source": {
@@ -1186,6 +1260,42 @@
                 "wordpress"
             ],
             "time": "2015-05-11 14:42:39"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "7369397beb792d1d9d5c4bee76c5cfa6221f6da5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/7369397beb792d1d9d5c4bee76c5cfa6221f6da5",
+                "reference": "7369397beb792d1d9d5c4bee76c5cfa6221f6da5",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "~2.2"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2015-08-31 19:36:48"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This PR closes #16; writing unit tests after having written the functionality is painfully boring, and I don't think I'm going to sit down and write them. Instead, I'm updating the documentation to require unit tests going forward, and we'll add them as we go. If you think this is a bad idea, let me know, and we'll leave that issue open.

This also adds code sniffer checks with composer scripts. Obviously, we're not fully in compliance yet, but it's worth making sure we don't get any worse, at least.